### PR TITLE
Added anchor to getPrettyDomain regex

### DIFF
--- a/webapp/scripts/core/lib.js
+++ b/webapp/scripts/core/lib.js
@@ -893,7 +893,7 @@ Lib.splitLines = function(text)
 
 Lib.getPrettyDomain = function(url)
 {
-    var m = /[^:]+:\/{1,3}(www\.)?([^\/]+)/.exec(url);
+    var m = /^[^:]+:\/{1,3}(www\.)?([^\/]+)/.exec(url);
     return m ? m[2] : "";
 },
 


### PR DESCRIPTION
I added an anchor to the regex in Lib.getPrettyDomain. As it was, it was unanchored.

I suspect this was probably a bug anyway (I don't know of a use case where there's a domain, but it isn't at the start of the URL), but it also had the side effect of making HAR files with long `data:` URLs slow to process.

Anchoring the regex solves both issues.

The test pack has been run against the changed code, and passes.
