### PR TITLE
Fix #25. Use feature detection for text selection.

### DIFF
--- a/webapp/scripts/core/lib.js
+++ b/webapp/scripts/core/lib.js
@@ -22,6 +22,7 @@ Lib.isIE      = /msie/.test(userAgent) && !/opera/.test(userAgent);
 Lib.isIE6     = /msie 6/i.test(navigator.appVersion);
 Lib.browserVersion = (userAgent.match( /.+(?:rv|it|ra|ie)[\/: ]([\d.]+)/ ) || [0,'0'])[1];
 Lib.isIElt8   = Lib.isIE && (Lib.browserVersion-0 < 8); 
+Lib.supportsSelectElementText = (window.getSelection && window.document.createRange) || (window.document.body.createTextRange);
 
 //***********************************************************************************************//
 // Core concepts (extension, dispatch, bind)

--- a/webapp/scripts/tabs/domTab.js
+++ b/webapp/scripts/tabs/domTab.js
@@ -84,8 +84,8 @@ DomTab.prototype = domplate(TabView.Tab.prototype,
     {
         this.toolbar.render(Lib.$(body, "domToolbar"));
 
-        // Lib.selectElementText doesn't support IE.
-        if (Lib.isIE)
+        // Lib.selectElementText doesn't support IE8 and below.
+        if (!Lib.supportsSelectElementText)
         {
             var searchBox = Lib.getElementByClass(body, "searchBox");
 


### PR DESCRIPTION
IE9 was being excluded from text selection functionality (because of the
isIE userAgent/regex test), even though IE9 supports the necessary APIs.

So this change replaces the isIE test with feature detection.