### PR TITLE
Issue 27 - Race condition when using the same callback name and jQuery JSONP

### DIFF
--- a/selenium/tests/hars/invalid.harp
+++ b/selenium/tests/hars/invalid.harp
@@ -1,4 +1,4 @@
-onInputData({
+callback_invalid({
     "log":{
         "entries":[{
             "time":360,

--- a/selenium/tests/hars/testLoad1.harp
+++ b/selenium/tests/hars/testLoad1.harp
@@ -1,4 +1,4 @@
-onInputData({
+callback_testLoad1({
   "log": {
     "version": "1.1",
     "creator": {

--- a/selenium/tests/hars/testLoad2.harp
+++ b/selenium/tests/hars/testLoad2.harp
@@ -1,4 +1,4 @@
-onInputData({
+callback_testLoad2({
   "log": {
     "version": "1.1",
     "creator": {

--- a/selenium/tests/testCustomPageTimingIndex.php
+++ b/selenium/tests/testCustomPageTimingIndex.php
@@ -7,8 +7,8 @@ $scriptsURL = $harviewer_base."scripts/";
 $cssURL = $harviewer_base."css/";
 ?>
 
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html>
 <head>
     <title>HTTP Archive Viewer Test</title>
 </head>

--- a/selenium/tests/testCustomizeColumnsPage.php
+++ b/selenium/tests/testCustomizeColumnsPage.php
@@ -8,8 +8,8 @@ $cssURL = $harviewer_base."css/";
 setcookie("previewCols", "url type timeline");
 ?>
 
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html>
 <head>
     <title>HTTP Archive Viewer Test</title>
 </head>

--- a/selenium/tests/testCustomizeColumnsPage2.php
+++ b/selenium/tests/testCustomizeColumnsPage2.php
@@ -5,8 +5,8 @@ $scriptsURL = $harviewer_base."scripts/";
 $cssURL = $harviewer_base."css/";
 ?>
 
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html>
 <head>
     <title>HTTP Archive Viewer Test</title>
 </head>

--- a/selenium/tests/testCustomizeColumnsPage3.php
+++ b/selenium/tests/testCustomizeColumnsPage3.php
@@ -2,8 +2,8 @@
 require_once("config.php");
 ?>
 
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html>
 <head>
     <title>HAR Viewer Test Case</title>
     <base href="<?php echo $harviewer_base ?>" />

--- a/selenium/tests/testEmbeddedInvalidPreview1.html.php
+++ b/selenium/tests/testEmbeddedInvalidPreview1.html.php
@@ -3,7 +3,7 @@ require_once("config.php");
 $url = $harviewer_base;
 ?>
 
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!doctype html>
 <html>
 <head>
   <title>Test Case for HAR Viewer</title>

--- a/selenium/tests/testEmbeddedInvalidPreview1.html.php
+++ b/selenium/tests/testEmbeddedInvalidPreview1.html.php
@@ -22,8 +22,8 @@ $url = $harviewer_base;
 
 <div id="preview" class="har"
     data-har="<?php echo $test_base.'tests/hars/invalid.harp' ?>"
+    data-callback="callback_invalid"
     validate="true"></div>
 
 </body>
 </html>
-

--- a/selenium/tests/testEmbeddedInvalidPreview2.html.php
+++ b/selenium/tests/testEmbeddedInvalidPreview2.html.php
@@ -3,7 +3,7 @@ require_once("config.php");
 $url = $harviewer_base;
 ?>
 
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!doctype html>
 <html>
 <head>
   <title>Test Case for HAR Viewer</title>

--- a/selenium/tests/testEmbeddedInvalidPreview2.html.php
+++ b/selenium/tests/testEmbeddedInvalidPreview2.html.php
@@ -22,8 +22,8 @@ $url = $harviewer_base;
 
 <div id="preview" class="har"
     data-har="<?php echo $test_base.'tests/hars/invalid.harp' ?>"
+    data-callback="callback_invalid"
     validate="false"></div>
 
 </body>
 </html>
-

--- a/selenium/tests/testEmbeddedPreview.html.php
+++ b/selenium/tests/testEmbeddedPreview.html.php
@@ -3,7 +3,7 @@ require_once("config.php");
 $url = $harviewer_base;
 ?>
 
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!doctype html>
 <html>
 <head>
   <title>Test Case for HAR Viewer</title>

--- a/selenium/tests/testEmbeddedPreview.html.php
+++ b/selenium/tests/testEmbeddedPreview.html.php
@@ -19,7 +19,8 @@ $url = $harviewer_base;
 
 <br/>
 
-<div id="preview3" class="har" data-har="<?php echo $test_base.'tests/hars/testLoad1.harp' ?>"></div>
+<div id="preview3" class="har" data-har="<?php echo $test_base.'tests/hars/testLoad1.harp' ?>"
+                               data-callback="callback_testLoad1"></div>
 
 <script>
 (function() {

--- a/selenium/tests/testHideTabBarIndex.php
+++ b/selenium/tests/testHideTabBarIndex.php
@@ -7,8 +7,8 @@ $scriptsURL = $harviewer_base."scripts/";
 $cssURL = $harviewer_base."css/";
 ?>
 
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html>
 <head>
     <title>HTTP Archive Viewer Test</title>
 </head>

--- a/selenium/tests/testLoadHarAPIPreview.html.php
+++ b/selenium/tests/testLoadHarAPIPreview.html.php
@@ -18,9 +18,8 @@ require_once("config.php");
     {
         // Get application object
         var viewer = event.target.repObject;
-        var settings = {jsonp: true};
-        viewer.loadHar("<?php echo $test_base.'tests/hars/testLoad1.harp' ?>", settings);
-        viewer.loadHar("<?php echo $test_base.'tests/hars/testLoad2.harp' ?>", settings);
+        viewer.loadHar("<?php echo $test_base.'tests/hars/testLoad1.harp' ?>", { jsonp: true, jsonpCallback: 'callback_testLoad1' });
+        viewer.loadHar("<?php echo $test_base.'tests/hars/testLoad2.harp' ?>", { jsonp: true, jsonpCallback: 'callback_testLoad2' });
         viewer.loadHar("<?php echo $test_base.'tests/hars/testLoad3.har' ?>");
     });
     </script>

--- a/selenium/tests/testLoadHarAPIPreview.html.php
+++ b/selenium/tests/testLoadHarAPIPreview.html.php
@@ -2,8 +2,8 @@
 require_once("config.php");
 ?>
 
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html>
 <head>
     <title>HAR Viewer Test Case</title>
     <base href="<?php echo $harviewer_base ?>" />

--- a/selenium/tests/testLoadHarAPIViewer.html.php
+++ b/selenium/tests/testLoadHarAPIViewer.html.php
@@ -19,9 +19,8 @@ require_once("config.php");
     {
         // Get application object
         var viewer = event.target.repObject;
-        var settings = {jsonp: true};
-        viewer.loadHar("<?php echo $test_base.'tests/hars/testLoad1.harp' ?>", settings);
-        viewer.loadHar("<?php echo $test_base.'tests/hars/testLoad2.harp' ?>", settings);
+        viewer.loadHar("<?php echo $test_base.'tests/hars/testLoad1.harp' ?>", { jsonp: true, jsonpCallback: 'callback_testLoad1' });
+        viewer.loadHar("<?php echo $test_base.'tests/hars/testLoad2.harp' ?>", { jsonp: true, jsonpCallback: 'callback_testLoad2' });
         viewer.loadHar("<?php echo $test_base.'tests/hars/testLoad3.har' ?>");
     });
     </script>

--- a/selenium/tests/testLoadHarAPIViewer.html.php
+++ b/selenium/tests/testLoadHarAPIViewer.html.php
@@ -2,8 +2,8 @@
 require_once("config.php");
 ?>
 
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html>
 <head>
     <title>HAR Viewer Test Case</title>
     <base href="<?php echo $harviewer_base ?>" />

--- a/selenium/tests/testPageListService.html.php
+++ b/selenium/tests/testPageListService.html.php
@@ -6,7 +6,7 @@ $url = $harviewer_base."loader.php?service=pagelist&amp;path=".
     $test_base."tests/simple-page-load.har&amp;expand=false";
 ?>
 
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+<!doctype html>
 <html>
 <head>
   <title>Test Case for HAR Viewer</title>

--- a/selenium/tests/testPreviewExpand.html.php
+++ b/selenium/tests/testPreviewExpand.html.php
@@ -2,8 +2,8 @@
 require_once("config.php");
 ?>
 
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html>
 <head>
     <title>HAR Viewer Test Case</title>
     <base href="<?php echo $harviewer_base ?>" />

--- a/selenium/tests/testRemoveTabIndex.php
+++ b/selenium/tests/testRemoveTabIndex.php
@@ -7,8 +7,8 @@ $scriptsURL = $harviewer_base."scripts/";
 $cssURL = $harviewer_base."css/";
 ?>
 
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html>
 <head>
     <title>HTTP Archive Viewer Test</title>
 </head>

--- a/selenium/tests/testRemoveToolbarButtonIndex.php
+++ b/selenium/tests/testRemoveToolbarButtonIndex.php
@@ -7,8 +7,8 @@ $scriptsURL = $harviewer_base."scripts/";
 $cssURL = $harviewer_base."css/";
 ?>
 
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html>
 <head>
     <title>HTTP Archive Viewer Test</title>
 </head>

--- a/selenium/tests/testSearchJsonQuery.html.php
+++ b/selenium/tests/testSearchJsonQuery.html.php
@@ -7,8 +7,8 @@ $cssURL = $harviewer_base."css/";
 setcookie("searchJsonQuery", "true");
 ?>
 
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html>
 <head>
     <title>HTTP Archive Viewer Test</title>
 </head>

--- a/selenium/tests/testShowStatsAndTimelineIndex.php
+++ b/selenium/tests/testShowStatsAndTimelineIndex.php
@@ -7,8 +7,8 @@ $scriptsURL = $harviewer_base."scripts/";
 $cssURL = $harviewer_base."css/";
 ?>
 
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html>
 <head>
     <title>HTTP Archive Viewer Test</title>
 </head>

--- a/webapp/har.js
+++ b/webapp/har.js
@@ -59,6 +59,8 @@ window.harInitialize = function()
         if (!path)
             continue;
 
+        var callback = element.getAttribute("data-callback");
+
         var width = element.getAttribute("width");
         var height = element.getAttribute("height");
         var expand = element.getAttribute("expand");
@@ -70,6 +72,9 @@ window.harInitialize = function()
 
         if (validate == "false")
             args += "&validate=false";
+
+        if (callback)
+            args += "&callback=" + callback;
 
         var iframe = document.createElement("iframe");
         iframe.setAttribute("style", "border: 1px solid lightgray;");

--- a/webapp/index.php
+++ b/webapp/index.php
@@ -1,5 +1,5 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html>
 <head>
     <title>HTTP Archive Viewer @VERSION@</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">

--- a/webapp/loader.php
+++ b/webapp/loader.php
@@ -1,5 +1,5 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html>
 <head>
     <title>HAR Viewer - Service Loader</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />

--- a/webapp/preview.php
+++ b/webapp/preview.php
@@ -1,5 +1,5 @@
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!doctype html>
+<html>
 <head>
     <title>HTTP Archive Preview @VERSION@</title>
 </head>

--- a/webapp/scripts/harPreview.js
+++ b/webapp/scripts/harPreview.js
@@ -60,9 +60,9 @@ HarPreview.prototype =
         }
     },
 
-    onError: function(response, ioArgs)
+    onError: function(jqXHR, textStatus, errorThrown)
     {
-        Trace.log("HarPreview; Load error ", response, ioArgs);
+        Trace.log("HarPreview; Load error ", jqXHR, textStatus, errorThrown);
     },
 
     // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
@@ -70,7 +70,7 @@ HarPreview.prototype =
 
     /**
      * Load HAR file. See {@link HarView.loadHar} for documentation.
-     */ 
+     */
     loadHar: function(url, settings)
     {
         settings = settings || {};

--- a/webapp/scripts/harViewer.js
+++ b/webapp/scripts/harViewer.js
@@ -38,7 +38,7 @@ function HarView()
 /**
  * This is the Application UI configuration code. The Viewer UI is based on a Tabbed UI
  * interface and is composed from following tabs:
- * 
+ *
  * {@link HomeTab}: This is the starting application tab. This tab allows direct inserting of
  *      a HAR log source to preview. There are also some useful links to existing example logs.
  *      This page is displyed by default unless there is a HAR file specified in the URL.
@@ -137,13 +137,13 @@ HarView.prototype = Lib.extend(new TabView(),
         Lib.fireEvent(content, "onViewerHARLoaded");
     },
 
-    onLoadError: function(response, ioArgs)
+    onLoadError: function(jqXHR, textStatus, errorThrown)
     {
         var homeTab = this.getTab("Home");
         if (homeTab)
-            homeTab.loadInProgress(true, response.statusText);
+            homeTab.loadInProgress(true, jqXHR.statusText);
 
-        Trace.error("harModule.loadRemoteArchive; ERROR ", response, ioArgs);
+        Trace.error("harModule.loadRemoteArchive; ERROR ", jqXHR, textStatus, errorThrown);
     },
 
     // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
@@ -176,7 +176,7 @@ HarView.prototype = Lib.extend(new TabView(),
 
     /**
      * Use to customize list of request columns displayed by default.
-     * 
+     *
      * @param {String} cols Column names separated by a space.
      * @param {Boolean} avoidCookies Set to true if you don't want to touch cookies.
      */

--- a/webapp/scripts/preview/harModel.js
+++ b/webapp/scripts/preview/harModel.js
@@ -382,9 +382,9 @@ HarModel.Loader =
                 callback(response);
             },
 
-            error: function(response, ioArgs)
+            error: function(jqXHR, textStatus, errorThrown)
             {
-                errorCallback(response, ioArgs);
+                errorCallback(jqXHR, textStatus, errorThrown);
             }
         });
 
@@ -425,10 +425,10 @@ HarModel.Loader =
                 }
             },
 
-            error: function(response, ioArgs)
+            error: function(jqXHR, textStatus, errorThrown)
             {
                 if (errorCallback)
-                    errorCallback(response, ioArgs);
+                    errorCallback(jqXHR, textStatus, errorThrown);
             }
         });
 
@@ -446,13 +446,13 @@ HarModel.Loader =
                 callback.call(scope, input);
         }
 
-        function onError(response, args)
+        function onError(jqXHR, textStatus, errorThrown)
         {
             if (scope.onLoadError)
-                scope.onLoadError(response, args);
+                scope.onLoadError(jqXHR, textStatus, errorThrown);
 
             if (errorCallback)
-                errorCallback.call(scope, response, args);
+                errorCallback.call(scope, jqXHR, textStatus, errorThrown);
         }
 
         if (crossDomain)

--- a/webapp/scripts/preview/harModel.js
+++ b/webapp/scripts/preview/harModel.js
@@ -376,6 +376,7 @@ HarModel.Loader =
         $.ajax({
             url: filePath,
             context: this,
+            dataType: "json",
 
             success: function(response)
             {

--- a/webapp/scripts/tabs/schemaTab.js
+++ b/webapp/scripts/tabs/schemaTab.js
@@ -36,9 +36,9 @@ SchemaTab.prototype =
                 dp.SyntaxHighlighter.HighlightAll(code);
             },
 
-            error: function(response, ioArgs)
+            error: function(jqXHR, textStatus, errorThrown)
             {
-                Trace.error("SchemaTab.onUpdateBody; ERROR ", response);
+                Trace.error("SchemaTab.onUpdateBody; ERROR ", jqXHR, textStatus, errorThrown);
             }
         });
     }


### PR DESCRIPTION
Fixes #27 

The main change here is the use of uniquely named callbacks to avoid jQuery JSONP callback name clashes.

Some tidy up was also required for the tests to pass more consistently:

- Use HTML5 doctype to coax IE9 into standards mode, for a standard impl of `document.querySelectorAll`.
- Use explicit "json" `dataType` (basically for Firefox) when requesting HAR files.

Some other tidy up:

- Replace the legacy Dojo XHR error callback parameters with jQuery ajax error callback parameters.

#### Test results

(all tests on Win7.  Ignore XP, Intern seems to report XP for some browsers)

````
> harviewer@1.0.0 test d:\dev\git_repos\harviewer2
> intern-runner config=tests/intern

✓ firefox 36.0.4 on WINDOWS - Test1 - testTabs
✓ firefox 37.0.2 on WINDOWS - Test1 - testTabs
✓ firefox 37.0.2 on WINDOWS - testPageListService - testPageListService
✓ firefox 37.0.2 on WINDOWS - testPreviewSource - testPreviewSource
✓ firefox 37.0.2 on WINDOWS - testRemoteLoad - testRemoteLoad
✓ firefox 37.0.2 on WINDOWS - testLoadMulipleFiles - testLoadMulipleFiles
✓ firefox 37.0.2 on WINDOWS - testNoPageLog - testNoPageLog
✓ firefox 37.0.2 on WINDOWS - testPageTimings - testPageTimings
✓ firefox 37.0.2 on WINDOWS - testSchemaTab - testSchemaTab
✓ firefox 37.0.2 on WINDOWS - testRequestBody - testUrlParams
✓ firefox 37.0.2 on WINDOWS - testRequestBody - testDataURL
✓ firefox 37.0.2 on WINDOWS - testRemoveTab - testRemoveTab
✓ firefox 37.0.2 on WINDOWS - testHideTabBar - testHideTabBar
✓ firefox 37.0.2 on WINDOWS - testShowStatsAndTimeline - testShowStatsAndTimeline
✓ firefox 37.0.2 on WINDOWS - testCustomPageTiming - testCustomPageTiming
✓ firefox 37.0.2 on WINDOWS - testRemoveToolbarButton - testRemoveToolbarButton
✓ firefox 37.0.2 on WINDOWS - testTimeStamps - testTimeStamps
✓ firefox 37.0.2 on WINDOWS - testPhases - testPhases
✓ firefox 37.0.2 on WINDOWS - testLoadHarAPI - testViewer
✓ firefox 37.0.2 on WINDOWS - testLoadHarAPI - testPreview
✓ firefox 37.0.2 on WINDOWS - testNoPageGraph - testNoPageGraph
✓ firefox 37.0.2 on WINDOWS - testEmbeddedPreview - testEmbeddedPreview
✓ firefox 37.0.2 on WINDOWS - testCustomizeColumns - 1
✓ firefox 37.0.2 on WINDOWS - testCustomizeColumns - 2
✓ firefox 37.0.2 on WINDOWS - testCustomizeColumns - 3
✓ firefox 37.0.2 on WINDOWS - testSearchHAR - testSearchHAR
✓ firefox 37.0.2 on WINDOWS - testPreviewExpand - testExpandSinglePage
✓ firefox 37.0.2 on WINDOWS - testPreviewExpand - testExpandMultiplePages
✓ firefox 37.0.2 on WINDOWS - testPreviewExpand - testExpandByDefault
✓ firefox 37.0.2 on WINDOWS - testEmbeddedInvalidPreview - testEmbeddedInvalidPreview1
✓ firefox 37.0.2 on WINDOWS - testEmbeddedInvalidPreview - testEmbeddedInvalidPreview2
✓ firefox 37.0.2 on WINDOWS - testSearchJsonQuery - testSearchJsonQuery
✓ chrome 43.0.2357.124 on XP - Test1 - testTabs
✓ chrome 43.0.2357.124 on XP - testExamples - testTabs
✓ chrome 43.0.2357.124 on XP - testPageListService - testPageListService
✓ chrome 43.0.2357.124 on XP - testPreviewSource - testPreviewSource
✓ chrome 43.0.2357.124 on XP - testRemoteLoad - testRemoteLoad
✓ chrome 43.0.2357.124 on XP - testLoadMulipleFiles - testLoadMulipleFiles
✓ chrome 43.0.2357.124 on XP - testNoPageLog - testNoPageLog
✓ chrome 43.0.2357.124 on XP - testPageTimings - testPageTimings
✓ chrome 43.0.2357.124 on XP - testSchemaTab - testSchemaTab
✓ chrome 43.0.2357.124 on XP - testRequestBody - testUrlParams
✓ chrome 43.0.2357.124 on XP - testRequestBody - testDataURL
✓ chrome 43.0.2357.124 on XP - testRemoveTab - testRemoveTab
✓ chrome 43.0.2357.124 on XP - testHideTabBar - testHideTabBar
✓ chrome 43.0.2357.124 on XP - testShowStatsAndTimeline - testShowStatsAndTimeline
✓ chrome 43.0.2357.124 on XP - testCustomPageTiming - testCustomPageTiming
✓ chrome 43.0.2357.124 on XP - testRemoveToolbarButton - testRemoveToolbarButton
✓ chrome 43.0.2357.124 on XP - testTimeStamps - testTimeStamps
✓ chrome 43.0.2357.124 on XP - testPhases - testPhases
✓ chrome 43.0.2357.124 on XP - testLoadHarAPI - testViewer
✓ chrome 43.0.2357.124 on XP - testLoadHarAPI - testPreview
✓ chrome 43.0.2357.124 on XP - testNoPageGraph - testNoPageGraph
✓ chrome 43.0.2357.124 on XP - testEmbeddedPreview - testEmbeddedPreview
✓ chrome 43.0.2357.124 on XP - testCustomizeColumns - 1
✓ chrome 43.0.2357.124 on XP - testCustomizeColumns - 2
✓ chrome 43.0.2357.124 on XP - testCustomizeColumns - 3
✓ chrome 43.0.2357.124 on XP - testSearchHAR - testSearchHAR
✓ chrome 43.0.2357.124 on XP - testPreviewExpand - testExpandSinglePage
✓ chrome 43.0.2357.124 on XP - testPreviewExpand - testExpandMultiplePages
✓ chrome 43.0.2357.124 on XP - testPreviewExpand - testExpandByDefault
✓ chrome 43.0.2357.124 on XP - testEmbeddedInvalidPreview - testEmbeddedInvalidPreview1
✓ chrome 43.0.2357.124 on XP - testEmbeddedInvalidPreview - testEmbeddedInvalidPreview2
✓ chrome 43.0.2357.124 on XP - testSearchJsonQuery - testSearchJsonQuery
✓ internet explorer 9 on WINDOWS - Test1 - testTabs
✓ internet explorer 9 on WINDOWS - testExamples - testTabs
✓ internet explorer 9 on WINDOWS - testPageListService - testPageListService
✓ internet explorer 9 on WINDOWS - testPreviewSource - testPreviewSource
✓ internet explorer 9 on WINDOWS - testRemoteLoad - testRemoteLoad
✓ internet explorer 9 on WINDOWS - testLoadMulipleFiles - testLoadMulipleFiles
✓ internet explorer 9 on WINDOWS - testNoPageLog - testNoPageLog
✓ internet explorer 9 on WINDOWS - testPageTimings - testPageTimings
✓ internet explorer 9 on WINDOWS - testSchemaTab - testSchemaTab
✓ internet explorer 9 on WINDOWS - testRequestBody - testUrlParams
✓ internet explorer 9 on WINDOWS - testRequestBody - testDataURL
✓ internet explorer 9 on WINDOWS - testRemoveTab - testRemoveTab
✓ internet explorer 9 on WINDOWS - testHideTabBar - testHideTabBar
✓ internet explorer 9 on WINDOWS - testShowStatsAndTimeline - testShowStatsAndTimeline
✓ internet explorer 9 on WINDOWS - testCustomPageTiming - testCustomPageTiming
✓ internet explorer 9 on WINDOWS - testRemoveToolbarButton - testRemoveToolbarButton
✓ internet explorer 9 on WINDOWS - testTimeStamps - testTimeStamps
✓ internet explorer 9 on WINDOWS - testPhases - testPhases
✓ internet explorer 9 on WINDOWS - testLoadHarAPI - testViewer
✓ internet explorer 9 on WINDOWS - testLoadHarAPI - testPreview
✓ internet explorer 9 on WINDOWS - testNoPageGraph - testNoPageGraph
✓ internet explorer 9 on WINDOWS - testEmbeddedPreview - testEmbeddedPreview
✓ internet explorer 9 on WINDOWS - testCustomizeColumns - 1
✓ internet explorer 9 on WINDOWS - testCustomizeColumns - 2
✓ internet explorer 9 on WINDOWS - testCustomizeColumns - 3
✓ internet explorer 9 on WINDOWS - testSearchHAR - testSearchHAR
✓ internet explorer 9 on WINDOWS - testPreviewExpand - testExpandSinglePage
✓ internet explorer 9 on WINDOWS - testPreviewExpand - testExpandMultiplePages
✓ internet explorer 9 on WINDOWS - testPreviewExpand - testExpandByDefault
✓ internet explorer 9 on WINDOWS - testEmbeddedInvalidPreview - testEmbeddedInvalidPreview1
✓ internet explorer 9 on WINDOWS - testEmbeddedInvalidPreview - testEmbeddedInvalidPreview2
✓ internet explorer 9 on WINDOWS - testSearchJsonQuery - testSearchJsonQuery
✓ firefox 37.0.2 on WINDOWS - testExamples - testTabs
✓ firefox 36.0.4 on WINDOWS - testExamples - testTabs
✓ firefox 36.0.4 on WINDOWS - testPageListService - testPageListService
✓ firefox 36.0.4 on WINDOWS - testPreviewSource - testPreviewSource
✓ firefox 36.0.4 on WINDOWS - testRemoteLoad - testRemoteLoad
✓ firefox 36.0.4 on WINDOWS - testLoadMulipleFiles - testLoadMulipleFiles
✓ firefox 36.0.4 on WINDOWS - testNoPageLog - testNoPageLog
✓ firefox 36.0.4 on WINDOWS - testPageTimings - testPageTimings
✓ firefox 36.0.4 on WINDOWS - testSchemaTab - testSchemaTab
✓ firefox 36.0.4 on WINDOWS - testRequestBody - testUrlParams
✓ firefox 36.0.4 on WINDOWS - testRequestBody - testDataURL
✓ firefox 36.0.4 on WINDOWS - testRemoveTab - testRemoveTab
✓ firefox 36.0.4 on WINDOWS - testHideTabBar - testHideTabBar
✓ firefox 36.0.4 on WINDOWS - testShowStatsAndTimeline - testShowStatsAndTimeline
✓ firefox 36.0.4 on WINDOWS - testCustomPageTiming - testCustomPageTiming
✓ firefox 36.0.4 on WINDOWS - testRemoveToolbarButton - testRemoveToolbarButton
✓ firefox 36.0.4 on WINDOWS - testTimeStamps - testTimeStamps
✓ firefox 36.0.4 on WINDOWS - testPhases - testPhases
✓ firefox 36.0.4 on WINDOWS - testLoadHarAPI - testViewer
✓ firefox 36.0.4 on WINDOWS - testLoadHarAPI - testPreview
✓ firefox 36.0.4 on WINDOWS - testNoPageGraph - testNoPageGraph
✓ firefox 36.0.4 on WINDOWS - testEmbeddedPreview - testEmbeddedPreview
✓ firefox 36.0.4 on WINDOWS - testCustomizeColumns - 1
✓ firefox 36.0.4 on WINDOWS - testCustomizeColumns - 2
✓ firefox 36.0.4 on WINDOWS - testCustomizeColumns - 3
✓ firefox 36.0.4 on WINDOWS - testSearchHAR - testSearchHAR
✓ firefox 36.0.4 on WINDOWS - testPreviewExpand - testExpandSinglePage
✓ firefox 36.0.4 on WINDOWS - testPreviewExpand - testExpandMultiplePages
✓ firefox 36.0.4 on WINDOWS - testPreviewExpand - testExpandByDefault
✓ firefox 36.0.4 on WINDOWS - testEmbeddedInvalidPreview - testEmbeddedInvalidPreview1
✓ firefox 36.0.4 on WINDOWS - testEmbeddedInvalidPreview - testEmbeddedInvalidPreview2
✓ firefox 36.0.4 on WINDOWS - testSearchJsonQuery - testSearchJsonQuery
✓ internet explorer 11 on WINDOWS - Test1 - testTabs
✓ internet explorer 11 on WINDOWS - testExamples - testTabs
✓ internet explorer 11 on WINDOWS - testPageListService - testPageListService
✓ internet explorer 11 on WINDOWS - testPreviewSource - testPreviewSource
✓ internet explorer 11 on WINDOWS - testRemoteLoad - testRemoteLoad
✓ internet explorer 11 on WINDOWS - testLoadMulipleFiles - testLoadMulipleFiles
✓ internet explorer 11 on WINDOWS - testNoPageLog - testNoPageLog
✓ internet explorer 11 on WINDOWS - testPageTimings - testPageTimings
✓ internet explorer 11 on WINDOWS - testSchemaTab - testSchemaTab
✓ internet explorer 11 on WINDOWS - testRequestBody - testUrlParams
✓ internet explorer 11 on WINDOWS - testRequestBody - testDataURL
✓ internet explorer 11 on WINDOWS - testRemoveTab - testRemoveTab
✓ internet explorer 11 on WINDOWS - testHideTabBar - testHideTabBar
✓ internet explorer 11 on WINDOWS - testShowStatsAndTimeline - testShowStatsAndTimeline
✓ internet explorer 11 on WINDOWS - testCustomPageTiming - testCustomPageTiming
✓ internet explorer 11 on WINDOWS - testRemoveToolbarButton - testRemoveToolbarButton
✓ internet explorer 11 on WINDOWS - testTimeStamps - testTimeStamps
✓ internet explorer 11 on WINDOWS - testPhases - testPhases
✓ internet explorer 11 on WINDOWS - testLoadHarAPI - testViewer
✓ internet explorer 11 on WINDOWS - testLoadHarAPI - testPreview
✓ internet explorer 11 on WINDOWS - testNoPageGraph - testNoPageGraph
✓ internet explorer 11 on WINDOWS - testEmbeddedPreview - testEmbeddedPreview
✓ internet explorer 11 on WINDOWS - testCustomizeColumns - 1
✓ internet explorer 11 on WINDOWS - testCustomizeColumns - 2
✓ internet explorer 11 on WINDOWS - testCustomizeColumns - 3
✓ internet explorer 11 on WINDOWS - testSearchHAR - testSearchHAR
✓ internet explorer 11 on WINDOWS - testPreviewExpand - testExpandSinglePage
✓ internet explorer 11 on WINDOWS - testPreviewExpand - testExpandMultiplePages
✓ internet explorer 11 on WINDOWS - testPreviewExpand - testExpandByDefault
✓ internet explorer 11 on WINDOWS - testEmbeddedInvalidPreview - testEmbeddedInvalidPreview1
✓ internet explorer 11 on WINDOWS - testEmbeddedInvalidPreview - testEmbeddedInvalidPreview2
✓ internet explorer 11 on WINDOWS - testSearchJsonQuery - testSearchJsonQuery
✓ phantomjs 2.0.0 on XP - Test1 - testTabs
✓ phantomjs 2.0.0 on XP - testExamples - testTabs
✓ phantomjs 2.0.0 on XP - testPageListService - testPageListService
✓ phantomjs 2.0.0 on XP - testPreviewSource - testPreviewSource
✓ phantomjs 2.0.0 on XP - testRemoteLoad - testRemoteLoad
✓ phantomjs 2.0.0 on XP - testLoadMulipleFiles - testLoadMulipleFiles
✓ phantomjs 2.0.0 on XP - testNoPageLog - testNoPageLog
✓ phantomjs 2.0.0 on XP - testPageTimings - testPageTimings
✓ phantomjs 2.0.0 on XP - testSchemaTab - testSchemaTab
✓ phantomjs 2.0.0 on XP - testRequestBody - testUrlParams
✓ phantomjs 2.0.0 on XP - testRequestBody - testDataURL
✓ phantomjs 2.0.0 on XP - testRemoveTab - testRemoveTab
✓ phantomjs 2.0.0 on XP - testHideTabBar - testHideTabBar
✓ phantomjs 2.0.0 on XP - testShowStatsAndTimeline - testShowStatsAndTimeline
✓ phantomjs 2.0.0 on XP - testCustomPageTiming - testCustomPageTiming
✓ phantomjs 2.0.0 on XP - testRemoveToolbarButton - testRemoveToolbarButton
✓ phantomjs 2.0.0 on XP - testTimeStamps - testTimeStamps
✓ phantomjs 2.0.0 on XP - testPhases - testPhases
✓ phantomjs 2.0.0 on XP - testLoadHarAPI - testViewer
✓ phantomjs 2.0.0 on XP - testLoadHarAPI - testPreview
✓ phantomjs 2.0.0 on XP - testNoPageGraph - testNoPageGraph
✓ phantomjs 2.0.0 on XP - testEmbeddedPreview - testEmbeddedPreview
✓ phantomjs 2.0.0 on XP - testCustomizeColumns - 1
✓ phantomjs 2.0.0 on XP - testCustomizeColumns - 2
✓ phantomjs 2.0.0 on XP - testCustomizeColumns - 3
✓ phantomjs 2.0.0 on XP - testSearchHAR - testSearchHAR
✓ phantomjs 2.0.0 on XP - testPreviewExpand - testExpandSinglePage
✓ phantomjs 2.0.0 on XP - testPreviewExpand - testExpandMultiplePages
✓ phantomjs 2.0.0 on XP - testPreviewExpand - testExpandByDefault
✓ phantomjs 2.0.0 on XP - testEmbeddedInvalidPreview - testEmbeddedInvalidPreview1
✓ phantomjs 2.0.0 on XP - testEmbeddedInvalidPreview - testEmbeddedInvalidPreview2
✓ phantomjs 2.0.0 on XP - testSearchJsonQuery - testSearchJsonQuery

tests/intern
Tunnel: Ready

Total: [✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓] 192/192
Passed: 192  Failed: 0    Skipped: 0

Fx 37 WIN:  [✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓] 32/32
Chr 43 XP:  [✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓] 32/32
IE 9 WIN:   [✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓] 32/32
Fx 36 WIN:  [✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓] 32/32
IE 11 WIN:  [✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓] 32/32
Phan 2 XP:  [✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓] 32/32

----------|-----------|-----------|-----------|-----------|
File      |   % Stmts |% Branches |   % Funcs |   % Lines |
----------|-----------|-----------|-----------|-----------|
----------|-----------|-----------|-----------|-----------|
All files |       100 |       100 |       100 |       100 |
----------|-----------|-----------|-----------|-----------|
````
