### PR TITLE
Test stability

### DIFF
--- a/selenium/tests/testCustomPageTimingIndex.php
+++ b/selenium/tests/testCustomPageTimingIndex.php
@@ -11,6 +11,7 @@ $cssURL = $harviewer_base."css/";
 <html>
 <head>
     <title>HTTP Archive Viewer Test</title>
+    <link rel="stylesheet" href="<?php echo $cssURL; ?>harViewer.css" type="text/css">
 </head>
 <body class="harBody">
     <div id="content" version="Test"></div>
@@ -29,6 +30,5 @@ $cssURL = $harviewer_base."css/";
         });
     });
     </script>
-    <link rel="stylesheet" href="<?php echo $cssURL; ?>harViewer.css" type="text/css"/>
 </body>
 </html>

--- a/selenium/tests/testCustomizeColumnsPage.php
+++ b/selenium/tests/testCustomizeColumnsPage.php
@@ -12,12 +12,12 @@ setcookie("previewCols", "url type timeline");
 <html>
 <head>
     <title>HTTP Archive Viewer Test</title>
+    <link rel="stylesheet" href="<?php echo $cssURL; ?>harViewer.css" type="text/css">
 </head>
 <body class="harBody">
     <div id="content" version="Test"></div>
     <!--[if IE]><script type="text/javascript" src="<?php echo $scriptsURL; ?>excanvas/excanvas.js"></script><![endif]-->
     <script src="<?php echo $scriptsURL; ?>jquery.js"></script>
     <script data-main="<?php echo $scriptsURL; ?>harViewer" src="<?php echo $scriptsURL; ?>require.js"></script>
-    <link rel="stylesheet" href="<?php echo $cssURL; ?>harViewer.css" type="text/css"/>
 </body>
 </html>

--- a/selenium/tests/testCustomizeColumnsPage2.php
+++ b/selenium/tests/testCustomizeColumnsPage2.php
@@ -9,6 +9,7 @@ $cssURL = $harviewer_base."css/";
 <html>
 <head>
     <title>HTTP Archive Viewer Test</title>
+    <link rel="stylesheet" href="<?php echo $cssURL; ?>harViewer.css" type="text/css">
 </head>
 <body class="harBody">
     <div id="content" version="Test"></div>
@@ -22,6 +23,5 @@ $cssURL = $harviewer_base."css/";
         viewer.setPreviewColumns("url status size timeline", true);
     });
     </script>
-    <link rel="stylesheet" href="<?php echo $cssURL; ?>harViewer.css" type="text/css"/>
 </body>
 </html>

--- a/selenium/tests/testCustomizeColumnsPage3.php
+++ b/selenium/tests/testCustomizeColumnsPage3.php
@@ -7,12 +7,12 @@ require_once("config.php");
 <head>
     <title>HAR Viewer Test Case</title>
     <base href="<?php echo $harviewer_base ?>" />
+    <link rel="stylesheet" href="css/harPreview.css" type="text/css">
 </head>
 <body style="margin:0">
     <div id="content" version="@VERSION@"></div>
     <script src="scripts/jquery.js"></script>
     <script data-main="scripts/harPreview" src="scripts/require.js"></script>
-    <link rel="stylesheet" href="css/harPreview.css" type="text/css"/>
     <script>
     $("#content").bind("onPreviewInit", function(event)
     {

--- a/selenium/tests/testHideTabBarIndex.php
+++ b/selenium/tests/testHideTabBarIndex.php
@@ -11,6 +11,7 @@ $cssURL = $harviewer_base."css/";
 <html>
 <head>
     <title>HTTP Archive Viewer Test</title>
+    <link rel="stylesheet" href="<?php echo $cssURL; ?>harViewer.css" type="text/css">
 </head>
 <body class="harBody">
     <div id="content" version="Test"></div>
@@ -24,6 +25,5 @@ $cssURL = $harviewer_base."css/";
         viewer.showTabBar(false);
     });
     </script>
-    <link rel="stylesheet" href="<?php echo $cssURL; ?>harViewer.css" type="text/css"/>
 </body>
 </html>

--- a/selenium/tests/testLoadHarAPIPreview.html.php
+++ b/selenium/tests/testLoadHarAPIPreview.html.php
@@ -7,12 +7,12 @@ require_once("config.php");
 <head>
     <title>HAR Viewer Test Case</title>
     <base href="<?php echo $harviewer_base ?>" />
+    <link rel="stylesheet" href="css/harPreview.css" type="text/css">
 </head>
 <body style="margin:0">
     <div id="content" version="@VERSION@"></div>
     <script src="scripts/jquery.js"></script>
     <script data-main="scripts/harPreview" src="scripts/require.js"></script>
-    <link rel="stylesheet" href="css/harPreview.css" type="text/css"/>
     <script>
     $("#content").bind("onPreviewInit", function(event)
     {

--- a/selenium/tests/testLoadHarAPIViewer.html.php
+++ b/selenium/tests/testLoadHarAPIViewer.html.php
@@ -7,13 +7,13 @@ require_once("config.php");
 <head>
     <title>HAR Viewer Test Case</title>
     <base href="<?php echo $harviewer_base ?>" />
+    <link rel="stylesheet" href="css/harViewer.css" type="text/css">
 </head>
 <body class="harBody">
     <div id="content" version="test"></div>
     <!--[if IE]><script type="text/javascript" src="scripts/excanvas/excanvas.js"></script><![endif]-->
     <script src="scripts/jquery.js"></script>
     <script data-main="scripts/harViewer" src="scripts/require.js"></script>
-    <link rel="stylesheet" href="css/harViewer.css" type="text/css"/>
     <script>
     $("#content").bind("onViewerInit", function(event)
     {

--- a/selenium/tests/testPreviewExpand.html.php
+++ b/selenium/tests/testPreviewExpand.html.php
@@ -7,11 +7,11 @@ require_once("config.php");
 <head>
     <title>HAR Viewer Test Case</title>
     <base href="<?php echo $harviewer_base ?>" />
+    <link rel="stylesheet" href="css/harPreview.css" type="text/css">
 </head>
 <body style="margin:0">
     <div id="content" version="@VERSION@"></div>
     <script src="scripts/jquery.js"></script>
     <script data-main="scripts/harPreview" src="scripts/require.js"></script>
-    <link rel="stylesheet" href="css/harPreview.css" type="text/css"/>
 </body>
 </html>

--- a/selenium/tests/testRemoveTabIndex.php
+++ b/selenium/tests/testRemoveTabIndex.php
@@ -11,6 +11,7 @@ $cssURL = $harviewer_base."css/";
 <html>
 <head>
     <title>HTTP Archive Viewer Test</title>
+    <link rel="stylesheet" href="<?php echo $cssURL; ?>harViewer.css" type="text/css">
 </head>
 <body class="harBody">
     <div id="content" version="Test"></div>
@@ -25,6 +26,5 @@ $cssURL = $harviewer_base."css/";
         viewer.removeTab("Schema");
     });
     </script>
-    <link rel="stylesheet" href="<?php echo $cssURL; ?>harViewer.css" type="text/css"/>
 </body>
 </html>

--- a/selenium/tests/testRemoveToolbarButtonIndex.php
+++ b/selenium/tests/testRemoveToolbarButtonIndex.php
@@ -11,6 +11,7 @@ $cssURL = $harviewer_base."css/";
 <html>
 <head>
     <title>HTTP Archive Viewer Test</title>
+    <link rel="stylesheet" href="<?php echo $cssURL; ?>harViewer.css" type="text/css">
 </head>
 <body class="harBody">
     <div id="content" version="Test"></div>
@@ -28,6 +29,5 @@ $cssURL = $harviewer_base."css/";
         preview.toolbar.removeButton("showStats");
     });
     </script>
-    <link rel="stylesheet" href="<?php echo $cssURL; ?>harViewer.css" type="text/css"/>
 </body>
 </html>

--- a/selenium/tests/testSearchJsonQuery.html.php
+++ b/selenium/tests/testSearchJsonQuery.html.php
@@ -11,12 +11,12 @@ setcookie("searchJsonQuery", "true");
 <html>
 <head>
     <title>HTTP Archive Viewer Test</title>
+    <link rel="stylesheet" href="<?php echo $cssURL; ?>harViewer.css" type="text/css">
 </head>
 <body class="harBody">
     <div id="content" version="Test"></div>
     <!--[if IE]><script type="text/javascript" src="<?php echo $scriptsURL; ?>excanvas/excanvas.js"></script><![endif]-->
     <script src="<?php echo $scriptsURL; ?>jquery.js"></script>
     <script data-main="<?php echo $scriptsURL; ?>harViewer" src="<?php echo $scriptsURL; ?>require.js"></script>
-    <link rel="stylesheet" href="<?php echo $cssURL; ?>harViewer.css" type="text/css"/>
 </body>
 </html>

--- a/selenium/tests/testShowStatsAndTimelineIndex.php
+++ b/selenium/tests/testShowStatsAndTimelineIndex.php
@@ -11,6 +11,7 @@ $cssURL = $harviewer_base."css/";
 <html>
 <head>
     <title>HTTP Archive Viewer Test</title>
+    <link rel="stylesheet" href="<?php echo $cssURL; ?>harViewer.css" type="text/css">
 </head>
 <body class="harBody">
     <div id="content" version="Test"></div>
@@ -26,6 +27,5 @@ $cssURL = $harviewer_base."css/";
         preview.showTimeline(true);
     });
     </script>
-    <link rel="stylesheet" href="<?php echo $cssURL; ?>harViewer.css" type="text/css"/>
 </body>
 </html>

--- a/tests/functional/test1.js
+++ b/tests/functional/test1.js
@@ -13,7 +13,9 @@ define([
     'testTabs': function() {
       var r = this.remote;
       var utils = new DriverUtils(r);
+      var timeout = 10 * 1000;
       return r
+        .setFindTimeout(timeout)
         .get(harViewerBase)
         .then(utils.cbAssertElementContainsText("css=.HomeTab", "Home"))
         .then(utils.cbAssertElementContainsText("css=.PreviewTab", "Preview"))

--- a/tests/functional/testPreviewSource.js
+++ b/tests/functional/testPreviewSource.js
@@ -26,10 +26,10 @@ define([
       return r
         .setFindTimeout(timeout)
         .get(harViewerBase)
-        // see gitgrimbo[1] for why the following three lines are commented and replaced by execute()
-        //.findById("sourceEditor")
-        //.type(har)
-        //.end()
+        // Wait for the #sourceEditor element
+        .findById("sourceEditor")
+        // End the element context
+        .end()
         .execute("document.getElementById('sourceEditor').value = '" + har + "'")
         // Click on the example link
         .findById("appendPreview")

--- a/webapp/index.php
+++ b/webapp/index.php
@@ -3,13 +3,13 @@
 <head>
     <title>HTTP Archive Viewer @VERSION@</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <link rel="stylesheet" href="css/harViewer.css" type="text/css">
 </head>
 <body class="harBody">
     <div id="content" version="@VERSION@"></div>
     <!--[if IE]><script type="text/javascript" src="scripts/excanvas/excanvas.js"></script><![endif]-->
     <script src="scripts/jquery.js"></script>
     <script data-main="scripts/harViewer" src="scripts/require.js"></script>
-    <link rel="stylesheet" href="css/harViewer.css" type="text/css"/>
     <?php include("ga.php") ?>
 </body>
 </html>

--- a/webapp/preview.php
+++ b/webapp/preview.php
@@ -2,12 +2,12 @@
 <html>
 <head>
     <title>HTTP Archive Preview @VERSION@</title>
+    <link rel="stylesheet" href="css/harPreview.css" type="text/css">
 </head>
 <body style="margin:0">
     <div id="content" version="@VERSION@"></div>
     <script src="scripts/jquery.js"></script>
     <script data-main="scripts/harPreview" src="scripts/require.js"></script>
-    <link rel="stylesheet" href="css/harPreview.css" type="text/css"/>
     <?php include("ga.php") ?>
 </body>
 </html>


### PR DESCRIPTION
A couple of tests were showing intermittent failures due to the asynchronous nature of the harviewer page load process.

As an aside it might be a good idea for harviewer to modify the document somehow when it has finished loading (e.g. add a `<body>` or `<html>` class).  This way the tests can explicitly wait for a signal from harviewer before commencing the actual test (locating DOM elements, etc).