### PR TITLE
Support inputURL via hash fragment in addition to query string

### DIFF
--- a/webapp/scripts/core/lib.js
+++ b/webapp/scripts/core/lib.js
@@ -21,7 +21,7 @@ Lib.isSafari  = /webkit/.test(userAgent);
 Lib.isIE      = /msie/.test(userAgent) && !/opera/.test(userAgent);
 Lib.isIE6     = /msie 6/i.test(navigator.appVersion);
 Lib.browserVersion = (userAgent.match( /.+(?:rv|it|ra|ie)[\/: ]([\d.]+)/ ) || [0,'0'])[1];
-Lib.isIElt8   = Lib.isIE && (Lib.browserVersion-0 < 8); 
+Lib.isIElt8   = Lib.isIE && (Lib.browserVersion-0 < 8);
 Lib.supportsSelectElementText = (window.getSelection && window.document.createRange) || (window.document.body.createTextRange);
 
 //***********************************************************************************************//
@@ -100,7 +100,7 @@ Lib.dispatch2 = function(listeners, name, args)
 // Type Checking
 
 var toString = Object.prototype.toString;
-var reFunction = /^\s*function(\s+[\w_$][\w\d_$]*)?\s*\(/; 
+var reFunction = /^\s*function(\s+[\w_$][\w\d_$]*)?\s*\(/;
 
 Lib.isArray = function(object)
 {
@@ -1024,7 +1024,7 @@ Lib.getElementPosition = function(el)
 Lib.getWindowSize = function()
 {
     var width=0, height=0, el;
-    
+
     if (typeof window.innerWidth == "number")
     {
         width = window.innerWidth;
@@ -1040,7 +1040,7 @@ Lib.getWindowSize = function()
         width = el.clientWidth;
         height = el.clientHeight;
     }
-    
+
     return {width: width, height: height};
 };
 
@@ -1049,7 +1049,7 @@ Lib.getWindowScrollSize = function()
     var width=0, height=0, el;
 
     // first try the document.documentElement scroll size
-    if (!Lib.isIEQuiksMode && (el=document.documentElement) && 
+    if (!Lib.isIEQuiksMode && (el=document.documentElement) &&
        (el.scrollHeight || el.scrollWidth))
     {
         width = el.scrollWidth;

--- a/webapp/scripts/core/lib.js
+++ b/webapp/scripts/core/lib.js
@@ -562,6 +562,26 @@ Lib.getURLParameters = function(name)
     return result;
 };
 
+/**
+ * Supports multiple hash parameters with the same name. Returns array
+ * of values.
+ * @param {String} name Name of the requested hash parameter.
+ * @return {Array} Array with values.
+ */
+Lib.getHashParameters = function(name)
+{
+    var result = [];
+    var query = window.location.hash.substring(1);
+    var vars = query.split("&");
+    for (var i=0;i<vars.length;i++)
+    {
+        var pair = vars[i].split("=");
+        if (pair[0] == name)
+            result.push(unescape(pair[1]));
+    }
+    return result;
+};
+
 Lib.parseURLParams = function(url)
 {
     var q = url ? url.indexOf("?") : -1;

--- a/webapp/scripts/preview/harModel.js
+++ b/webapp/scripts/preview/harModel.js
@@ -334,7 +334,7 @@ HarModel.Loader =
 
         var paths = Lib.getURLParameters("path");
         var callbackName = Lib.getURLParameter("callback");
-        var inputUrls = Lib.getURLParameters("inputUrl");
+        var inputUrls = Lib.getURLParameters("inputUrl").concat(Lib.getHashParameters("inputUrl"));
 
         //for (var p in inputUrls)
         //    inputUrls[p] = inputUrls[p].replace(/%/g,'%25');


### PR DESCRIPTION
Closes #31. Hash fragment and query string can be used with the same results.

![screen shot 2015-07-01 at 6 32 49 pm](https://cloud.githubusercontent.com/assets/829698/8465345/c08f58b8-201f-11e5-99cb-2743b8a7bc12.png)
