### PR TITLE
Lib.getPrettyDomain now avoids data URIs. Also placed a limit in case…

### DIFF
--- a/webapp/scripts/core/lib.js
+++ b/webapp/scripts/core/lib.js
@@ -914,7 +914,9 @@ Lib.splitLines = function(text)
 
 Lib.getPrettyDomain = function(url)
 {
-    var m = /^[^:]+:\/{1,3}(www\.)?([^\/]+)/.exec(url);
+    // Large data URIs cause performance problems.
+    // 255 is the FQDN length limit per RFC 1035.
+    var m = /^(?!data:)[^:]+:\/{1,3}(www\.)?([^\/]{1,256})/.exec(url);
     return m ? m[2] : "";
 },
 


### PR DESCRIPTION
… of other long URIs that do not have domains.

There was a performance problem where the browser could hang when the document contained lots of data URIs. ESPN.com is a good test case for this.