### PR TITLE
Fix #35 String.prototype.startsWith absent in IE

### DIFF
--- a/webapp/scripts/core/lib.js
+++ b/webapp/scripts/core/lib.js
@@ -854,6 +854,12 @@ Lib.setClassTimed = function(elt, name, timeout)
 //*************************************************************************************************
 // Text
 
+Lib.startsWith = function(str, searchString, position)
+{
+    position = position || 0;
+    return str.indexOf(searchString, position) === position;
+};
+
 Lib.trim = function(text)
 {
     return text.replace(/^\s*|\s*$/g, "");

--- a/webapp/scripts/preview/requestBody.js
+++ b/webapp/scripts/preview/requestBody.js
@@ -95,8 +95,8 @@ RequestBody.prototype = domplate(
         // there can be a charset specified. So, check the prefix.
         var mimeType = file.response.content.mimeType || "";
         var fileMimeType = file.mimeType || "";
-        return (mimeType.startsWith("text/html")) ||
-            (fileMimeType.startsWith("application/xhtml+xml"));
+        return (Lib.startsWith(mimeType, "text/html")) ||
+            (Lib.startsWith(fileMimeType, "application/xhtml+xml"));
     },
 
     showDataURL: function(file)


### PR DESCRIPTION
The commit to fix #22 introduced a small regression as `String.prototype.startsWith` is not supported in IE.

09c0d68#diff-e192ba09633197436e388a54f4cc9d8bR98

Add `Lib.startsWith` method.

Support for `String.prototype.startsWith`:

https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith