### PR TITLE
Update Intern from 2.2.2 to 3.0.0 and some test tidyup

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -15,6 +15,16 @@
     <property name="rjs.cmd" value="${basedir}/r.js/dist/r.js"/>
     <property name="rjs.runner" value="node"/>
 
+    <property name="selenium.server.version" value="2.47.1"/>
+    <property name="selenium.server.version.major" value="2.47"/>
+    <property name="selenium.server.url" value="https://selenium-release.storage.googleapis.com/${selenium.server.version.major}/selenium-server-standalone-${selenium.server.version}.jar"/>
+    <property name="iedriver.version" value="2.47.0"/>
+    <property name="iedriver.filename" value="IEDriverServer_Win32_${iedriver.version}.zip"/>
+    <property name="iedriver.url" value="https://selenium-release.storage.googleapis.com/${selenium.server.version.major}/${iedriver.filename}"/>
+    <property name="chromedriver.version" value="2.16"/>
+    <property name="chromedriver.filename" value="chromedriver_win32.zip"/>
+    <property name="chromedriver.url" value="http://chromedriver.storage.googleapis.com/${chromedriver.version}/${chromedriver.filename}"/>
+
     <!-- Tools for building release package of HAR Viewer.
         js-build-tools: http://code.google.com/p/js-build-tools/
         js-min (ant task): http://code.google.com/p/jsmin-ant-task/
@@ -40,6 +50,35 @@
     <!-- Remove the previous HAR Viewer build. -->
     <target name="clean">
         <delete dir="${build.dir}"/>
+    </target>
+
+
+
+
+
+    <!--
+    Downloads selenium server.  Selenium server is required for testing.
+    -->
+    <target name="get-iedriver">
+        <property name="iedriver.dir" value="${basedir}/selenium/iedriver"/>
+        <mkdir dir="${iedriver.dir}"/>
+        <get dest="${iedriver.dir}" verbose="true">
+            <url url="${iedriver.url}" />
+        </get>
+        <unzip src="${iedriver.dir}/${iedriver.filename}" dest="${basedir}/selenium"/>
+    </target>
+
+    <target name="get-chromedriver">
+        <property name="chromedriver.dir" value="${basedir}/selenium/chromedriver"/>
+        <mkdir dir="${chromedriver.dir}"/>
+        <get dest="${chromedriver.dir}" verbose="true">
+            <url url="${chromedriver.url}" />
+        </get>
+        <unzip src="${chromedriver.dir}/${chromedriver.filename}" dest="${basedir}/selenium"/>
+    </target>
+
+    <target name="get-selenium" depends="get-iedriver, get-chromedriver">
+        <get src="${selenium.server.url}" dest="${basedir}/selenium/server/selenium-server.jar" verbose="true"/>
     </target>
 
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "The purpose of this online tool is to visualize HTTP Archive (HAR) log files created by HTTP tracking tools. These files contain log of HTTP client/server conversation and can be used for an additional analysis of e.g. page load performance.",
   "devDependencies": {
-    "intern": "~2.2.2"
+    "intern": "~3.0.0"
   },
   "scripts": {
     "test": "intern-runner config=tests/intern"

--- a/selenium/start-server-hub.bat
+++ b/selenium/start-server-hub.bat
@@ -1,0 +1,2 @@
+title selenium-hub
+java -Dfile.encoding=UTF-8 -jar %~dp0server\selenium-server.jar -role hub

--- a/selenium/start-server.bat
+++ b/selenium/start-server.bat
@@ -1,10 +1,16 @@
-set FIREFOX_PATH=c:\apps\Mozilla Firefox 37
-set IE_DRIVER_PATH=d:\dev\git_repos\harviewer2\selenium\iedriver\2.45.0
-set CHROME_DRIVER_EXE=d:\dev\git_repos\harviewer2\selenium\chromedriver\2.15\chromedriver.exe
+REM Assumes IEDriverServer.exe and chromedriver.exe are in the same folder as this batch file.
 
-set path=%FIREFOX_PATH%;%IE_DRIVER_PATH%;%PATH%
+set          FIREFOX_EXE=c:\apps\Mozilla Firefox 37\firefox.exe
+set        IE_DRIVER_EXE=%~dp0IEDriverServer.exe
+set    CHROME_DRIVER_EXE=%~dp0chromedriver.exe
+set        PHANTOMJS_EXE=c:\apps\phantomjs\2.0.0\bin\phantomjs.exe
 
-set CHROME_DRIVER_ARG=-Dwebdriver.chrome.driver="%CHROME_DRIVER_EXE%"
+set    CHROME_DRIVER_ARG=-Dwebdriver.chrome.driver="%CHROME_DRIVER_EXE%"
+set        IE_DRIVER_ARG=-Dwebdriver.ie.driver="%IE_DRIVER_EXE%"
+set   FIREFOX_DRIVER_ARG=-Dwebdriver.firefox.bin="%FIREFOX_EXE%"
+set PHANTOMJS_DRIVER_ARG=-Dphantomjs.binary.path="%PHANTOMJS_EXE%"
+
+set DRIVER_ARGS=%FIREFOX_DRIVER_ARG% %CHROME_DRIVER_ARG% %IE_DRIVER_ARG% %PHANTOMJS_DRIVER_ARG%
 
 REM java -jar server/selenium-server.jar -debug
-java -jar server/selenium-server.jar %CHROME_DRIVER_ARG% -debug
+java -jar %~dp0server\selenium-server.jar %DRIVER_ARGS% -debug

--- a/selenium/tests/config.php
+++ b/selenium/tests/config.php
@@ -2,4 +2,18 @@
 # don't forget the trailing slash
 $harviewer_base = "http://legoas/src/github.com/janodvarko/harviewer/webapp-build/";
 $test_base = "http://legoas/src/github.com/janodvarko/harviewer/selenium/";
+
+# For Selenium grid testing, the Selenium nodes must be able to access a
+# HAR Viewer server called "harviewer" on port "49001".
+
+# This host can be mapped in the node's hosts file.
+
+# Or change "http://harviewer" below to "http://a.b.c.d" where "a.b.c.d" is the
+# IP address of the HAR Viewer server.
+
+# Or change "http://harviewer" to "http://localhost" to run Selenium
+# in standalone mode (not grid).
+
+#$harviewer_base = "http://harviewer:49001/webapp/";
+#$test_base = "http://harviewer:49001/selenium/";
 ?>

--- a/tests/README.txt
+++ b/tests/README.txt
@@ -3,24 +3,39 @@ Versions tested for compatibility (11 Jun 2015):
 Windows:
 
 - Node v0.12.4.
-- Intern 2.2.2.
+- Intern 3.0.0.
 - Firefox 27.0.2.
-- Chrome 43.0.2357.124 using chromedriver.exe 2.15.
+- Chrome 44.0.2403.155 m using chromedriver.exe 2.16.
 - PhantomJS 2.0.0.
-- IE 11 (32bit) using IEDriverServer.exe 2.45.0 (32bit).
+- IE 11 (32bit) using IEDriverServer.exe 2.47.0 (32bit).
 - Java 1.8.0_45.
-- Selenium 2.45.0.
+- Selenium 2.47.1.
 
-Run All Selenium Tests for HAR Viewer:
+
+
+
+
+Run unit tests
+--------------
+
+Start a web server from the project root, and browse to the "client.html" page. E.g.:
+
+http://localhost:9999/node_modules/intern/client.html?config=tests/intern
+
+
+
+
+
+HAR Viewer tests - Selenium Standalone
 --------------------------------------
-1) Set your HAR viewer server base path in tests/intern.js, e.g.:
+1) Set your HAR Viewer server base path in tests/intern-selenium-standalone.js, e.g.:
 
     harviewer: {
-      harViewerBase: 'http://192.168.59.103:8000/webapp/',
-      testBase: 'http://192.168.59.103:8000/selenium/'
+      harViewerBase: 'http://localhost:49001/webapp/',
+      testBase: 'http://localhost:49001/selenium/'
     },
 
-2) Go to the selenium directory and run Selenium using:
+2) Go to the selenium directory and run Selenium Standalone using:
 
     start-server.bat
 
@@ -29,9 +44,32 @@ This command has placeholders for the locations of:
 - A specific version of Firefox to use (for compatibility with Selenium).
 - The location of IEDriverServer.exe.
 - The location of chromedriver.exe.
-
-If PhantomJS is also to be used as a target browser, then make sure phantomjs.exe is on the PATH.
+- The location of phantomjs.exe.
 
 3) Now go to the harviewer project root directory and run Intern tests:
 
-    npm test
+    node node_modules\intern\bin\intern-runner.js config=tests/intern-selenium-standalone
+
+
+
+
+
+HAR Viewer tests - Selenium grid
+--------------------------------
+
+1) Set your HAR Viewer server base path in tests/intern-selenium-grid.js, e.g.:
+
+    harviewer: {
+      harViewerBase: 'http://harviewer:49001/webapp/',
+      testBase: 'http://harviewer:49001/selenium/'
+    },
+
+2) Go to the selenium directory and run Selenium Hub using:
+
+    start-server-hub.bat
+
+3) Start your Selenium nodes.
+
+4) Now go to the harviewer project root directory and run Intern tests:
+
+    node node_modules\intern\bin\intern-runner.js config=tests/intern-selenium-grid

--- a/tests/functional-suites.js
+++ b/tests/functional-suites.js
@@ -1,0 +1,33 @@
+/**
+ * Functional test suites.
+ */
+define([
+], function() {
+    return [
+      'tests/functional/test1',
+      'tests/functional/testExamples',
+      'tests/functional/testPageListService',
+      'tests/functional/testPreviewSource',
+      'tests/functional/testRemoteLoad',
+      'tests/functional/testLoadMultipleFiles',
+      'tests/functional/testNoPageLog',
+      'tests/functional/testPageTimings',
+      'tests/functional/testSchemaTab',
+      'tests/functional/testRequestBody',
+      'tests/functional/testRemoveTab',
+      'tests/functional/testHideTabBar',
+      'tests/functional/testShowStatsAndTimeline',
+      'tests/functional/testCustomPageTiming',
+      'tests/functional/testRemoveToolbarButton',
+      'tests/functional/testTimeStamps',
+      'tests/functional/testPhases',
+      'tests/functional/testLoadHarAPI',
+      'tests/functional/testNoPageGraph',
+      'tests/functional/testEmbeddedPreview',
+      'tests/functional/testCustomizeColumns',
+      'tests/functional/testSearchHAR',
+      'tests/functional/testPreviewExpand',
+      'tests/functional/testEmbeddedInvalidPreview',
+      'tests/functional/testSearchJsonQuery'
+    ];
+});

--- a/tests/functional/DriverUtils.js
+++ b/tests/functional/DriverUtils.js
@@ -6,8 +6,8 @@ define([
   "intern/chai!assert",
   'intern/dojo/node!leadfoot/helpers/pollUntil',
   'intern/dojo/node!leadfoot/Command',
-  'intern/dojo/Deferred'
-], function(assert, pollUntil, Command, Deferred) {
+  'intern/dojo/Promise'
+], function(assert, pollUntil, Command, Promise) {
 
   function logThen(msg, formatIt) {
     return function(it) {
@@ -28,9 +28,9 @@ define([
 
   function waitFor(ms) {
     return function() {
-      var d = new Deferred();
-      setTimeout(d.resolve.bind(d), ms);
-      return d.promise;
+      return new Promise(function(resolve, reject) {
+        setTimeout(resolve, ms);
+      });
     };
   }
 

--- a/tests/functional/test1.js
+++ b/tests/functional/test1.js
@@ -13,9 +13,9 @@ define([
     'testTabs': function() {
       var r = this.remote;
       var utils = new DriverUtils(r);
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(harViewerBase)
         .then(utils.cbAssertElementContainsText("css=.HomeTab", "Home"))
         .then(utils.cbAssertElementContainsText("css=.PreviewTab", "Preview"))

--- a/tests/functional/testCustomPageTiming.js
+++ b/tests/functional/testCustomPageTiming.js
@@ -18,7 +18,7 @@ define([
     'testCustomPageTiming': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
@@ -26,12 +26,14 @@ define([
       var harFileURL = testBase + "tests/testCustomPageTiming.har";
       var url = viewerURL + "?path=" + harFileURL;
 
+      var pollTimeout = findTimeout;
+
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         // Return null or undefined to indicate poll not successful (yet).
         // http://theintern.github.io/leadfoot/pollUntil.html
-        .then(pollUntil("return (document.querySelectorAll('.onMyEventBar.netPageTimingBar.netBar').length == 4) || null;", 10 * 1000))
+        .then(pollUntil("return (document.querySelectorAll('.onMyEventBar.netPageTimingBar.netBar').length == 4) || null;", pollTimeout))
         // xxxHonza: remove the trailing and begin space in the class attribute (domplate).
         .findAllByXpath("//div[@class=' onMyEventBar  netPageTimingBar netBar ']")
         .then(function(els) {

--- a/tests/functional/testCustomizeColumns.js
+++ b/tests/functional/testCustomizeColumns.js
@@ -36,7 +36,7 @@ define([
     '1': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
@@ -46,7 +46,7 @@ define([
       var url = viewerURL + "?path=" + harFileURL;
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         .findByCssSelector(".PreviewTab.selected")
         // Make sure we are in the Preview tab.
@@ -66,7 +66,7 @@ define([
     '2': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
@@ -76,7 +76,7 @@ define([
       var url = viewerURL + "?path=" + harFileURL;
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         .findByCssSelector(".PreviewTab.selected")
         // Make sure we are in the Preview tab.
@@ -96,7 +96,7 @@ define([
     '3': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
@@ -106,9 +106,9 @@ define([
       var url = viewerURL + "?path=" + harFileURL + "&expand=true";
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
-        .then(pollUntil("return document.querySelector('.pageTable .pageRow.opened');", timeout))
+        .then(pollUntil("return document.querySelector('.pageTable .pageRow.opened');", findTimeout))
         // Check columns visibility
         // gitgrimbo
         // Add .netRow class to ensure we get a table cell that should have a clientWidth when we want it to.

--- a/tests/functional/testEmbeddedInvalidPreview.js
+++ b/tests/functional/testEmbeddedInvalidPreview.js
@@ -18,7 +18,7 @@ define([
     'testEmbeddedInvalidPreview1': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
@@ -26,22 +26,22 @@ define([
       var url = testBase + "tests/testEmbeddedInvalidPreview1.html.php";
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         .findByCssSelector("iframe")
-        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview', '.errorTable'], timeout))
+        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview', '.errorTable'], findTimeout))
         .then(function(len) {
           assert.strictEqual(len, 1, "#preview1.errorTable");
         })
-        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview', '.errorRow'], timeout))
+        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview', '.errorRow'], findTimeout))
         .then(function(len) {
           assert.strictEqual(len, 1, "#preview1.errorRow");
         })
-        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview', '.errorProperty'], timeout))
+        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview', '.errorProperty'], findTimeout))
         .then(function(len) {
           assert.strictEqual(len, 1, "#preview1.errorProperty");
         })
-        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview', '.errorMessage'], timeout))
+        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview', '.errorMessage'], findTimeout))
         .then(function(len) {
           assert.strictEqual(len, 1, "#preview1.errorMessage");
         });
@@ -50,7 +50,7 @@ define([
     'testEmbeddedInvalidPreview2': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
@@ -58,14 +58,14 @@ define([
       var url = testBase + "tests/testEmbeddedInvalidPreview2.html.php";
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         .findByCssSelector("iframe")
-        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview', '.pageTable'], timeout))
+        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview', '.pageTable'], findTimeout))
         .then(function(len) {
           assert.strictEqual(len, 1, "#preview1.pageTable");
         })
-        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview', '.netRow'], timeout))
+        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview', '.netRow'], findTimeout))
         .then(function(len) {
           assert.strictEqual(len, 49, "#preview1.errorRow");
         });

--- a/tests/functional/testEmbeddedPreview.js
+++ b/tests/functional/testEmbeddedPreview.js
@@ -18,37 +18,37 @@ define([
     'testEmbeddedPreview': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
       var url = testBase + "tests/testEmbeddedPreview.html.php";
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
-        .then(DriverUtils.waitForElements("iframe", 3, timeout))
-        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview1', '.pageTable'], timeout))
+        .then(DriverUtils.waitForElements("iframe", 3, findTimeout))
+        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview1', '.pageTable'], findTimeout))
         .then(function(len) {
           assert.strictEqual(len, 1, "#preview1.pageTable");
         })
-        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview2', '.pageTable'], timeout))
+        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview2', '.pageTable'], findTimeout))
         .then(function(len) {
           assert.strictEqual(len, 1, "#preview2.pageTable");
         })
-        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview3', '.pageTable'], timeout))
+        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview3', '.pageTable'], findTimeout))
         .then(function(len) {
           assert.strictEqual(len, 1, "#preview3.pageTable");
         })
-        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview1', '.netRow'], timeout))
+        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview1', '.netRow'], findTimeout))
         .then(function(len) {
           assert.strictEqual(len, 2, "#preview3.netRow");
         })
-        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview2', '.netRow'], timeout))
+        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview2', '.netRow'], findTimeout))
         .then(function(len) {
           assert.strictEqual(len, 2, "#preview2.netRow");
         })
-        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview3', '.netRow'], timeout))
+        .then(pollUntil(DriverUtils.querySelectAllInFrameAndReturnLengthOrNull, ['#preview3', '.netRow'], findTimeout))
         .then(function(len) {
           assert.strictEqual(len, 11, "#preview3.netRow");
         })

--- a/tests/functional/testExamples.js
+++ b/tests/functional/testExamples.js
@@ -29,10 +29,10 @@ define([
     'testTabs': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(harViewerBase)
         .then(cbLoadAndVerify(r, "example1", "Cuzillion"))
         .then(cbLoadAndVerify(r, "example2", "Cuzillion"))

--- a/tests/functional/testHideTabBar.js
+++ b/tests/functional/testHideTabBar.js
@@ -18,14 +18,14 @@ define([
     'testHideTabBar': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
       var url = testBase + "tests/testHideTabBarIndex.php";
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         .findByCssSelector(".harView[hidetabbar='true']");
     }

--- a/tests/functional/testLoadHarAPI.js
+++ b/tests/functional/testLoadHarAPI.js
@@ -36,18 +36,18 @@ define([
     'testViewer': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
       var url = testBase + "tests/testLoadHarAPIViewer.html.php";
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         // Open customized viewer.
         .get(url)
         // Wait for 10 sec to load HAR files.
-        .then(pollUntil("return (document.querySelectorAll('.pageTable').length == 3) || null", timeout))
+        .then(pollUntil("return (document.querySelectorAll('.pageTable').length == 3) || null", findTimeout))
         .then(utils.cbAssertElementContainsText("css=.PreviewTab.selected", "Preview"))
         .then(utils.cbAssertElementsLength(".pageTable", 3));
       },
@@ -55,18 +55,18 @@ define([
       'testPreview': function() {
         // Some of these tests need a larger timeout for finding DOM elements
         // because we need the HAR to parse/display fully before we query the DOM.
-        var timeout = 10 * 1000;
+        var findTimeout = intern.config.harviewer.findTimeout;
         var r = this.remote;
         var utils = new DriverUtils(r);
 
         var url = testBase + "tests/testLoadHarAPIPreview.html.php";
 
         return r
-          .setFindTimeout(timeout)
+          .setFindTimeout(findTimeout)
           // Open customized preview.
           .get(url)
           // Wait for 10 sec to load HAR files.
-          .then(pollUntil("return (document.querySelectorAll('.pageTable').length == 3) || null", timeout))
+          .then(pollUntil("return (document.querySelectorAll('.pageTable').length == 3) || null", findTimeout))
           .then(utils.cbAssertElementsLength(".pageTable", 3));
         }
   });

--- a/tests/functional/testLoadMultipleFiles.js
+++ b/tests/functional/testLoadMultipleFiles.js
@@ -18,7 +18,7 @@ define([
     'testLoadMulipleFiles': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
@@ -34,13 +34,15 @@ define([
       // path=1.har&path=2.har&path=3.har&path=4.har&path=5.har&
       // path=6.har&path=7.har&path=8.har&path=9.har
 
+      var waitForFilesToLoadMs = findTimeout;
+
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         // Wait for 10 sec to load all 9 HAR files.
         // Return null or undefined to indicate poll not successful (yet).
         // http://theintern.github.io/leadfoot/pollUntil.html
-        .then(pollUntil("return (document.querySelectorAll('.pageTable').length == 9) || null;", 10 * 1000))
+        .then(pollUntil("return (document.querySelectorAll('.pageTable').length == 9) || null;", waitForFilesToLoadMs))
         .then(null, function(err) {
           // ignore pollUntil timeout error
           return 0;

--- a/tests/functional/testNoPageGraph.js
+++ b/tests/functional/testNoPageGraph.js
@@ -18,7 +18,7 @@ define([
     'testNoPageGraph': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
@@ -26,9 +26,9 @@ define([
       var url = harViewerBase + "?path=" + testBase + "tests/hars/noPages.har";
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
-        .then(DriverUtils.waitForElements(".PreviewTab.selected", 1, timeout))
+        .then(DriverUtils.waitForElements(".PreviewTab.selected", 1, findTimeout))
         // Make sure we are in the Preview tab.
         .then(utils.cbAssertElementContainsText("css=.PreviewTab.selected", "Preview"))
         // There must be 87 requests entries.

--- a/tests/functional/testNoPageLog.js
+++ b/tests/functional/testNoPageLog.js
@@ -17,7 +17,7 @@ define([
     'testNoPageLog': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
@@ -26,7 +26,7 @@ define([
       var url = harViewerBase + "?path=" + testBase + "tests/hars/testNoPageLog.har";
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         .then(utils.cbAssertElementContainsText("css=.PreviewTab.selected", "Preview"))
         .then(utils.cbAssertElementContainsText("css=.previewList", "GET test.txt"));

--- a/tests/functional/testPageListService.js
+++ b/tests/functional/testPageListService.js
@@ -14,11 +14,11 @@ define([
     'testPageListService': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(testBase + "tests/testPageListService.html.php")
         .switchToFrame("pageList")
         .findById("loadButton")

--- a/tests/functional/testPageTimings.js
+++ b/tests/functional/testPageTimings.js
@@ -18,7 +18,7 @@ define([
     'testPageTimings': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
@@ -28,7 +28,7 @@ define([
       var url = harViewerBase + "?path=" + testBase + "tests/hars/noPageTimings.har";
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         // The Preview tab must be selected and example HAR file loaded.
         .then(utils.cbAssertElementContainsText("css=.PreviewTab.selected", "Preview"))

--- a/tests/functional/testPhases.js
+++ b/tests/functional/testPhases.js
@@ -18,17 +18,17 @@ define([
     'testPhases': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
       var url = harViewerBase + "?path=" + testBase + "tests/hars/three-phases.har";
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         // There must be 3 phases in the waterfall graph and so, the layout broken two times.
-        .then(DriverUtils.waitForElements(".netRow.loaded[breakLayout=\"true\"]", 2, timeout))
+        .then(DriverUtils.waitForElements(".netRow.loaded[breakLayout=\"true\"]", 2, findTimeout))
         .then(function(els) {
           assert.lengthOf(els, 2);
         });

--- a/tests/functional/testPreviewExpand.js
+++ b/tests/functional/testPreviewExpand.js
@@ -17,7 +17,7 @@ define([
     'testExpandSinglePage': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
@@ -27,7 +27,7 @@ define([
       var url = viewerURL + "?path=" + harFileURL;
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         .findByCssSelector(".pageRow.opened");
     },
@@ -35,7 +35,7 @@ define([
     'testExpandMultiplePages': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
@@ -45,7 +45,7 @@ define([
       var url = viewerURL + "?path=" + harFileURL;
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         .findByCssSelector(".pageTable")
         .then(utils.cbAssertElementsLength(".pageRow", 3))
@@ -55,7 +55,7 @@ define([
     'testExpandByDefault': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
@@ -65,7 +65,7 @@ define([
       var url = viewerURL + "?path=" + harFileURL + "&expand=true";
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         .findByCssSelector(".pageTable")
         .then(utils.cbAssertElementsLength(".pageRow.opened", 3));

--- a/tests/functional/testPreviewSource.js
+++ b/tests/functional/testPreviewSource.js
@@ -17,14 +17,14 @@ define([
     'testPreviewSource': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
       var har = '{ "log":{ "version":"1.1", "creator":{ "name":"Firebug", "version":"1.6X.0a11" }, "browser":{ "name":"Firefox", "version":"3.6.3" }, "pages":[{ "startedDateTime":"2010-05-26T00:08:58.245+02:00", "id":"page_33141", "title":"http://legoas/har/viewer/selenium/tests/test.txt", "pageTimings":{ "onContentLoad":87, "onLoad":102 } } ], "entries":[{ "pageref":"page_33141", "startedDateTime":"2010-05-26T00:08:58.245+02:00", "time":5, "request":{ "method":"GET", "url":"http://legoas/har/viewer/selenium/tests/test.txt", "httpVersion":"HTTP/1.1", "cookies":[], "headers":[{ "name":"Host", "value":"legoas" }, { "name":"User-Agent", "value":"Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 (.NET CLR 3.5.30729)" }, { "name":"Accept", "value":"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8" }, { "name":"Accept-Language", "value":"en-us,en;q=0.5" }, { "name":"Accept-Encoding", "value":"gzip,deflate" }, { "name":"Accept-Charset", "value":"ISO-8859-1,utf-8;q=0.7,*;q=0.7" }, { "name":"Keep-Alive", "value":"115" }, { "name":"Connection", "value":"keep-alive" } ], "queryString":[], "headersSize":415, "bodySize":-1 }, "response":{ "status":200, "statusText":"OK","httpVersion":"HTTP/1.1", "cookies":[], "headers":[{ "name":"Date", "value":"Tue, 25 May 2010 22:09:38 GMT" }, { "name":"Server", "value":"Apache/2.2.11 (Win32) PHP/5.2.8" }, { "name":"Last-Modified", "value":"Tue, 25 May 2010 22:08:46 GMT" }, { "name":"Etag", "value":"none" }, { "name":"Accept-Ranges", "value":"bytes" }, { "name":"Content-Length", "value":"8" }, { "name":"Keep-Alive", "value":"timeout=5, max=100" }, { "name":"Connection", "value":"Keep-Alive" }, { "name":"Content-Type", "value":"text/plain" } ], "content":{ "size":8, "mimeType":"text/plain", "text":"Response" }, "redirectURL":"", "headersSize":306, "bodySize":8}, "cache":{}, "timings":{ "dns":1, "connect":2, "blocked":0, "send":0, "wait":2, "receive":0 } } ] }}';
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(harViewerBase)
         // Wait for the #sourceEditor element
         .findById("sourceEditor")

--- a/tests/functional/testRemoteLoad.js
+++ b/tests/functional/testRemoteLoad.js
@@ -19,11 +19,11 @@ define([
 
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         .then(utils.cbAssertElementContainsText("css=.PreviewTab.selected", "Preview"));
     }

--- a/tests/functional/testRemoveTab.js
+++ b/tests/functional/testRemoveTab.js
@@ -18,14 +18,14 @@ define([
     'testRemoveTab': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
       var url = testBase + "tests/testRemoveTabIndex.php";
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         .findByCssSelector(".HomeTab.selected")
         .end()

--- a/tests/functional/testRemoveToolbarButton.js
+++ b/tests/functional/testRemoveToolbarButton.js
@@ -18,14 +18,14 @@ define([
     'testRemoveToolbarButton': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
       var url = testBase + "tests/testRemoveToolbarButtonIndex.php";
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url);
         // gitgrimbo
         // Are we missing some assertions here?

--- a/tests/functional/testRequestBody.js
+++ b/tests/functional/testRequestBody.js
@@ -18,14 +18,14 @@ define([
     'testUrlParams': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
       var url = harViewerBase + "?path=" + testBase + "tests/hars/url-params.har";
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         // The Preview tab must be selected
         .then(utils.cbAssertElementContainsText("css=.PreviewTab.selected", "Preview"))
@@ -54,14 +54,14 @@ define([
     'testDataURL': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
       var url = harViewerBase + "?path=" + testBase + "tests/hars/data-url.har";
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         // The Preview tab must be selected
         .then(utils.cbAssertElementContainsText("css=.PreviewTab.selected", "Preview"))

--- a/tests/functional/testSchemaTab.js
+++ b/tests/functional/testSchemaTab.js
@@ -18,12 +18,12 @@ define([
     'testSchemaTab': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(harViewerBase)
         .then(utils.cbAssertElementContainsText("css=.SchemaTab", "Schema"))
         .findByCssSelector(".SchemaTab")

--- a/tests/functional/testSearchHAR.js
+++ b/tests/functional/testSearchHAR.js
@@ -19,7 +19,7 @@ define([
     'testSearchHAR': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
@@ -27,7 +27,7 @@ define([
       var url = harViewerBase + "?path=" + testBase + "tests/hars/searchHAR.har";
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         // Wait for the HAR to load by waiting for the Preview tab to be auto-selected
         .then(utils.cbAssertElementContainsText("css=.PreviewTab.selected", "Preview"))
@@ -51,7 +51,7 @@ define([
         //.pressKeys(keys.ENTER)
         //.pressKeys(keys.RETURN)
         // Check selection on the page.
-        .then(pollUntil("return (window.getSelection().toString() == 'Fire') || null;", timeout));
+        .then(pollUntil("return (window.getSelection().toString() == 'Fire') || null;", findTimeout));
     }
   });
 });

--- a/tests/functional/testSearchJsonQuery.js
+++ b/tests/functional/testSearchJsonQuery.js
@@ -19,7 +19,7 @@ define([
     'testSearchJsonQuery': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
@@ -28,7 +28,7 @@ define([
       var url = viewerURL + "?path=" + harFileURL;
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         // Wait for the HAR to load by waiting for the Preview tab to be auto-selected
         .then(utils.cbAssertElementContainsText("css=.PreviewTab.selected", "Preview"))
@@ -46,7 +46,7 @@ define([
         .end()
         .findByCssSelector(".tabDOMBody .domBox .results.visible")
         .end()
-        .then(utils.cbAssertElementsLength(".tabDOMBody .domBox .results .memberRow", 8, timeout));
+        .then(utils.cbAssertElementsLength(".tabDOMBody .domBox .results .memberRow", 8, findTimeout));
     }
   });
 });

--- a/tests/functional/testShowStatsAndTimeline.js
+++ b/tests/functional/testShowStatsAndTimeline.js
@@ -18,7 +18,7 @@ define([
     'testShowStatsAndTimeline': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
@@ -27,7 +27,7 @@ define([
       var url = viewerURL + "?path=" + harFileURL;
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         .then(utils.cbAssertElementContainsText("css=.PreviewTab.selected", "Preview"))
         .findByCssSelector(".pageTimelineBody.opened")

--- a/tests/functional/testTimeStamps.js
+++ b/tests/functional/testTimeStamps.js
@@ -18,7 +18,7 @@ define([
     'testTimeStamps': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
-      var timeout = 10 * 1000;
+      var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
@@ -27,13 +27,13 @@ define([
       var url = harViewerBase + "?path=" + testBase + "tests/hars/time-stamps.har";
 
       return r
-        .setFindTimeout(timeout)
+        .setFindTimeout(findTimeout)
         .get(url)
         .findByCssSelector(".PreviewTab.selected")
         // Make sure we are in the Preview tab.
         .then(utils.cbAssertElementContainsText("css=.PreviewTab.selected", "Preview"))
         // There must be 6 time stamps bars (3 per request * 2 requests)
-        .then(DriverUtils.waitForElements(".netTimeStampBar.netBar", 6, timeout))
+        .then(DriverUtils.waitForElements(".netTimeStampBar.netBar", 6, findTimeout))
         // Check position on the waterfall graph
         .execute(function() {
           var bars = window.document.querySelectorAll(".netTimeStampBar.netBar");

--- a/tests/intern-selenium-grid.js
+++ b/tests/intern-selenium-grid.js
@@ -1,0 +1,85 @@
+/**
+ * This is sample Intern config to use with a Selenium grid.
+ *
+ * There is config for three Selenium nodes that must have already been
+ * registered with the Selenium grid.
+ *
+ * The nodes need to be able to access the Intern proxy and a HAR Viewer
+ * server.  Both the proxy and HAR Viewer server are declared here to be
+ * available on a host called "harviewer". This host name can be changed to
+ * an IP address if preferred.
+ *
+ * This config will not start the Selenium grid, or the Selenium nodes, or
+ * the Intern proxy. The grid and nodes need to be started separately, and the
+ * Intern proxy will be started when the tests are run.
+ *
+ * The "harviewer.harViewerBase" and "harviewer.testBase" URLs also need to be
+ * set in "selenium/tests/config.php".
+ */
+define([
+  'intern/dojo/lang',
+  './intern',
+  './functional-suites'
+], function(lang, base, functionalSuites) {
+  var config = {
+    // The port on which the instrumenting proxy will listen
+    proxyPort: 9000,
+
+    // A fully qualified URL to the Intern proxy
+    proxyUrl: 'http://harviewer:9000/',
+
+    // Location of the Selenium grid.
+    tunnelOptions: {
+      hostname: 'harviewer',
+      port: 4444
+    },
+
+    // These are custom properties that the tests can grab.
+    // harViewerBase: The root URL to the harviewer app.
+    // testBase: The root URL to the harviewer test pages, HARs and HARPs.
+    harviewer: {
+      harViewerBase: 'http://harviewer:49001/webapp/',
+      testBase: 'http://harviewer:49001/selenium/',
+      findTimeout: 30 * 1000
+    },
+
+    // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
+    // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
+    // capabilities options specified for an environment will be copied as-is
+    environments: [],
+
+    // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
+    maxConcurrency: 4,
+
+    functionalSuites: functionalSuites
+  };
+
+  var node1 = [{
+    browserName: 'firefox',
+    version: '37'
+  }, {
+    browserName: 'chrome',
+    version: '44'
+  }, {
+    browserName: 'internet explorer',
+    version: '9'
+  }];
+
+  var node2 = [{
+    browserName: 'firefox',
+    version: '27'
+  }, {
+    browserName: 'internet explorer',
+    version: '11'
+  }];
+
+  var node3 = [{
+    browserName: 'phantomjs'
+  }];
+
+  config.environments = config.environments.concat(node1);
+  config.environments = config.environments.concat(node2);
+  config.environments = config.environments.concat(node3);
+
+  return lang.mixin({}, base, config);
+});

--- a/tests/intern-selenium-standalone.js
+++ b/tests/intern-selenium-standalone.js
@@ -1,0 +1,49 @@
+/**
+ * This is sample Intern config to use with a standalone Selenium server.
+ *
+ * If any of firefox, chrome, internet explorer or phantomjs are not installed
+ * on your machine, then remove/comment those browsers out from the
+ * "environments" array.
+ */
+define([
+  'intern/dojo/lang',
+  './intern',
+  './functional-suites'
+], function(lang, base, functionalSuites) {
+  var config = {
+    // The port on which the instrumenting proxy will listen
+    proxyPort: 9000,
+
+    // A fully qualified URL to the Intern proxy
+    proxyUrl: 'http://localhost:9000/',
+
+    // These are custom properties that the tests can grab.
+    // harViewerBase: The root URL to the harviewer app.
+    // testBase: The root URL to the harviewer test pages, HARs and HARPs.
+    harviewer: {
+      harViewerBase: 'http://localhost:49001/webapp/',
+      testBase: 'http://localhost:49001/selenium/',
+      findTimeout: 30 * 1000
+    },
+
+    // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
+    // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
+    // capabilities options specified for an environment will be copied as-is
+    environments: [{
+      browserName: 'firefox'
+    }, {
+      browserName: 'chrome'
+    }, {
+      browserName: 'internet explorer'
+    }, {
+      browserName: 'phantomjs'
+    }],
+
+    // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
+    maxConcurrency: 4,
+
+    functionalSuites: functionalSuites
+  };
+
+  return lang.mixin({}, base, config);
+});

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -16,8 +16,11 @@ define([
     // testBase: The root URL to the harviewer test pages, HARs and HARPs.
     harviewer: {
       harViewerBase: 'http://192.168.59.103:8000/webapp/',
-      testBase: 'http://192.168.59.103:8000/selenium/'
+      testBase: 'http://192.168.59.103:8000/selenium/',
+      findTimeout: 30 * 1000
     },
+
+    defaultTimeout: 60 * 1000,
 
     // Default desired capabilities for all environments. Individual capabilities can be overridden by any of the
     // specified browser environments in the `environments` array below as well. See

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -46,13 +46,16 @@ define([
     maxConcurrency: 4,
 
     //reporters: ['runner'],
-    reporters: ['pretty', 'junit'],
+    reporters: [
+      'Pretty',
+      { 'id': 'JUnit', 'filename': 'report.xml' }
+    ],
     //reporters: ['console', 'junit'],
     //reporters: ['html'],
 
     // Configuration options for the module loader; any AMD configuration options supported by the Dojo loader can be
     // used here
-    loader: {},
+    loaderOptions: {},
 
     // Non-functional test suite(s) to run in each browser
     suites: [

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -1,62 +1,21 @@
-// Learn more about configuring this file at <https://github.com/theintern/intern/wiki/Configuring-Intern>.
-// These default settings work OK for most people. The options that *must* be changed below are the
-// packages, suites, excludeInstrumentation, and (if you want functional tests) functionalSuites.
+/**
+ * Base Intern config for HAR Viewer.
+ *
+ * Look at intern-selenium-standalone.js and intern-selenium-grid.js for
+ * config for functional testing.
+ */
 define([
 ], function() {
   var config = {
-    // The port on which the instrumenting proxy will listen
-    proxyPort: 9000,
-
-    // A fully qualified URL to the Intern proxy
-    proxyUrl: 'http://localhost:9000/',
-
-    // gitgrimbo
-    // These are custom properties that the tests can grab.
-    // harViewerBase: The root URL to the harviewer app.
-    // testBase: The root URL to the harviewer test pages, HARs and HARPs.
-    harviewer: {
-      harViewerBase: 'http://192.168.59.103:8000/webapp/',
-      testBase: 'http://192.168.59.103:8000/selenium/',
-      findTimeout: 30 * 1000
-    },
 
     defaultTimeout: 60 * 1000,
 
-    // Default desired capabilities for all environments. Individual capabilities can be overridden by any of the
-    // specified browser environments in the `environments` array below as well. See
-    // https://code.google.com/p/selenium/wiki/DesiredCapabilities for standard Selenium capabilities and
-    // https://saucelabs.com/docs/additional-config#desired-capabilities for Sauce Labs capabilities.
-    // Note that the `build` capability will be filled in with the current commit ID from the Travis CI environment
-    // automatically
-    capabilities: {
-      'selenium-version': '2.45.0'
-    },
-
-    // Browsers to run integration testing against. Note that version numbers must be strings if used with Sauce
-    // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
-    // capabilities options specified for an environment will be copied as-is
-    environments: [{
-      browserName: 'firefox'
-    }, {
-      browserName: 'chrome'
-    }, {
-      browserName: 'ie'
-    }, {
-      browserName: 'phantomjs'
-    }],
-
-    // Maximum number of simultaneous integration tests that should be executed on the remote WebDriver service
-    maxConcurrency: 4,
-
-    //reporters: ['runner'],
     reporters: [
       'Pretty',
       'Lcov',
       'LcovHtml',
       { 'id': 'JUnit', 'filename': 'report.xml' }
     ],
-    //reporters: ['console', 'junit'],
-    //reporters: ['html'],
 
     // Configuration options for the module loader; any AMD configuration options supported by the Dojo loader can be
     // used here
@@ -69,35 +28,6 @@ define([
       'intern/node_modules/dojo/has!host-browser?tests/unit/unit',
       'tests/unit/core/lib',
       'tests/unit/core/cookies'
-    ],
-
-    // Functional test suite(s) to run in each browser once non-functional tests are completed
-    functionalSuites: [
-      'tests/functional/test1',
-      'tests/functional/testExamples',
-      'tests/functional/testPageListService',
-      'tests/functional/testPreviewSource',
-      'tests/functional/testRemoteLoad',
-      'tests/functional/testLoadMultipleFiles',
-      'tests/functional/testNoPageLog',
-      'tests/functional/testPageTimings',
-      'tests/functional/testSchemaTab',
-      'tests/functional/testRequestBody',
-      'tests/functional/testRemoveTab',
-      'tests/functional/testHideTabBar',
-      'tests/functional/testShowStatsAndTimeline',
-      'tests/functional/testCustomPageTiming',
-      'tests/functional/testRemoveToolbarButton',
-      'tests/functional/testTimeStamps',
-      'tests/functional/testPhases',
-      'tests/functional/testLoadHarAPI',
-      'tests/functional/testNoPageGraph',
-      'tests/functional/testEmbeddedPreview',
-      'tests/functional/testCustomizeColumns',
-      'tests/functional/testSearchHAR',
-      'tests/functional/testPreviewExpand',
-      'tests/functional/testEmbeddedInvalidPreview',
-      'tests/functional/testSearchJsonQuery'
     ],
 
     // A regular expression matching URLs to files that should not be included

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -48,6 +48,8 @@ define([
     //reporters: ['runner'],
     reporters: [
       'Pretty',
+      'Lcov',
+      'LcovHtml',
       { 'id': 'JUnit', 'filename': 'report.xml' }
     ],
     //reporters: ['console', 'junit'],
@@ -55,11 +57,15 @@ define([
 
     // Configuration options for the module loader; any AMD configuration options supported by the Dojo loader can be
     // used here
-    loaderOptions: {},
+    loaderOptions: {
+      packages: [{name: 'core', location: 'webapp/scripts/core'}]
+    },
 
     // Non-functional test suite(s) to run in each browser
     suites: [
-      'intern/node_modules/dojo/has!host-browser?tests/unit/unit'
+      'intern/node_modules/dojo/has!host-browser?tests/unit/unit',
+      'tests/unit/core/lib',
+      'tests/unit/core/cookies'
     ],
 
     // Functional test suite(s) to run in each browser once non-functional tests are completed
@@ -91,8 +97,41 @@ define([
       'tests/functional/testSearchJsonQuery'
     ],
 
-    // A regular expression matching URLs to files that should not be included in code coverage analysis
-    excludeInstrumentation: /^intern|tests|bower_components|node_modules[\\/]/
+    // A regular expression matching URLs to files that should not be included
+    // in code coverage analysis.
+
+    // Some of the patterns listed here can also be used in a reverse proxy to
+    // prevent any files that should not be instrumented from even reaching the
+    // Intern proxy.
+
+    // WARNING - PhantomJS does not seem to like [Istanbul code coverage /
+    // large JS files] combination.  Thus you may find the PhantomJS tests fail
+    // when testing the built "webapp-build" files with instrumentation turned
+    // on.  In this case you can set excludeInstrumentation to true, to
+    // completely disable instrumentation.
+    // See https://theintern.github.io/intern/#option-excludeInstrumentation
+    excludeInstrumentation: new RegExp([
+        // Exclude Intern's own files
+        '^intern/',
+
+        // Exclude test files
+        '^tests/',
+
+        // Exclude any 3rd party components installed via package manager
+        '^bower_components/',
+        '^node_modules/',
+
+        // Exclude any 3rd party components in HAR Viewer's own source
+        'scripts/jquery.js$',
+        'scripts/require.js$',
+        'scripts/text.js$',
+        'scripts/i18n.js$',
+
+        // Exclude any 3rd party components in HAR Viewer's own source
+        '/downloadify/',
+        '/json-query/',
+        '/syntax-highlighter/'
+      ].join('|'))
   };
 
   return config;

--- a/tests/unit/core/cookies.js
+++ b/tests/unit/core/cookies.js
@@ -1,0 +1,12 @@
+/**
+ * Simple unit test to sanity check that Intern is working.
+ */
+define([
+    'intern!object',
+    'intern/chai!assert',
+    'core/cookies'
+], function (registerSuite, assert, Cookies) {
+    registerSuite({
+        name: 'cookies'
+    });
+});

--- a/tests/unit/core/lib.js
+++ b/tests/unit/core/lib.js
@@ -1,0 +1,16 @@
+/**
+ * Simple unit test to sanity check that Intern is working.
+ */
+define([
+    'intern!object',
+    'intern/chai!assert',
+    'core/lib'
+], function (registerSuite, assert, Lib) {
+    registerSuite({
+        name: 'lib',
+
+        formatNumber: function () {
+            assert.strictEqual(Lib.formatNumber(0), '0', '[] is array');
+        }
+    });
+});


### PR DESCRIPTION
The changes are almost exclusively limited to the Intern tests, but with some extra comments/documentation.

The `build.xml` file has been enhanced to be able to download Selenium server and the IE and Chrome drivers (by running `ant get-selenium`).  This should mean that the copy of `selenium-server.jar` in the repo can be removed if desired.