### PR TITLE
Fix checkbox handling - replace jQ attr with prop

### DIFF
--- a/tests/functional-suites.js
+++ b/tests/functional-suites.js
@@ -29,6 +29,7 @@ define([
       'tests/functional/testPreviewExpand',
       'tests/functional/testEmbeddedInvalidPreview',
       'tests/functional/testSearchJsonQuery',
-      'tests/functional/testIssue39'
+      'tests/functional/testIssue39',
+      'tests/functional/testValidateCheckbox'
     ];
 });

--- a/tests/functional/DriverUtils.js
+++ b/tests/functional/DriverUtils.js
@@ -34,6 +34,26 @@ define([
     };
   }
 
+  /**
+   * Returns a function that can be used as a parameter to a Command's then() method.
+   * E.g.
+   *     .then(getCookie("validate"))
+   *     .then(function(cookie) { ... })
+   */
+  function getCookie(name) {
+    return function() {
+      return this.session.getCookies().then(function(cookies) {
+        for (var i = 0; i < cookies.length; i++) {
+          var webDriverCookie = cookies[i];
+          if (name === webDriverCookie.name) {
+            return webDriverCookie;
+          }
+        }
+        return null;
+      });
+    };
+  };
+
   var syntaxBridge = {
     assertElementContainsText: function(driver, locator, text) {
       var elPromise = null;
@@ -113,6 +133,7 @@ define([
   DriverUtils.logThen = logThen;
   DriverUtils.pluck = pluck;
   DriverUtils.waitFor = waitFor;
+  DriverUtils.getCookie = getCookie;
 
   // For every function in syntaxBridge, we attach TWO functions to DriverUtils,
   // and TWO functions to DriverUtils.prototype.

--- a/tests/functional/testValidateCheckbox.js
+++ b/tests/functional/testValidateCheckbox.js
@@ -1,0 +1,53 @@
+define([
+  'intern',
+  'intern!object',
+  'intern/chai!assert',
+  'require',
+  './DriverUtils',
+  'intern/dojo/node!leadfoot/helpers/pollUntil'
+], function(intern, registerSuite, assert, require, DriverUtils, pollUntil) {
+  var harViewerBase = intern.config.harviewer.harViewerBase;
+  var testBase = intern.config.harviewer.testBase;
+
+  registerSuite({
+    name: 'testValidateCheckbox',
+
+    /**
+     * "Validate data before processing" and "Table View" checkbox bug
+     * https://github.com/janodvarko/harviewer/issues/44
+     */
+    'testValidateCheckbox': function() {
+      // Some of these tests need a larger timeout for finding DOM elements
+      // because we need the HAR to parse/display fully before we query the DOM.
+      var findTimeout = intern.config.harviewer.findTimeout;
+      var r = this.remote;
+      var utils = new DriverUtils(r);
+
+      return r
+        .setFindTimeout(findTimeout)
+        .get(harViewerBase)
+        .findById("validate")
+        .then(DriverUtils.getCookie("validate"))
+        .then(function(cookie) {
+          assert.isNull(cookie);
+        })
+        // "Validate" checkbox is already checked (it has a HTML attribute of checked="true"),
+        // so clicking it should set to false.
+        .click()
+        .then(DriverUtils.getCookie("validate"))
+        .then(function(cookie) {
+          assert.isObject(cookie);
+          assert.strictEqual(cookie.name, "validate");
+          assert.strictEqual(cookie.value, "false");
+        })
+        // Clicking again should set to true.
+        .click()
+        .then(DriverUtils.getCookie("validate"))
+        .then(function(cookie) {
+          assert.isObject(cookie);
+          assert.strictEqual(cookie.name, "validate");
+          assert.strictEqual(cookie.value, "true");
+        })
+    }
+  });
+});

--- a/webapp/scripts/harViewer.js
+++ b/webapp/scripts/harViewer.js
@@ -91,7 +91,7 @@ HarView.prototype = Lib.extend(new TabView(),
 
         try
         {
-            var validate = $("#validate").attr("checked");
+            var validate = $("#validate").prop("checked");
             var input = HarModel.parse(jsonString, validate);
             this.model.append(input);
 

--- a/webapp/scripts/tabs/domTab.js
+++ b/webapp/scripts/tabs/domTab.js
@@ -305,7 +305,7 @@ DomTab.prototype = domplate(TabView.Tab.prototype,
         var target = e.target;
 
         var tab = Lib.getAncestorByClass(target, "tabBody");
-        var tableView = $(target).attr("checked");
+        var tableView = $(target).prop("checked");
         tab.repObject.tableView = tableView;
 
         var resultBox = Lib.getAncestorByClass(target, "results");

--- a/webapp/scripts/tabs/homeTab.js
+++ b/webapp/scripts/tabs/homeTab.js
@@ -56,7 +56,7 @@ HomeTab.prototype = Lib.extend(TabView.Tab.prototype,
         this.validateNode = $("#validate");
         var validate = Cookies.getCookie("validate");
         if (validate)
-            this.validateNode.attr("checked", (validate == "false") ? false : true);
+            this.validateNode.prop("checked", (validate == "false") ? false : true);
         this.validateNode.change(Lib.bind(this.onValidationChange, this))
 
         // Load examples
@@ -82,7 +82,7 @@ HomeTab.prototype = Lib.extend(TabView.Tab.prototype,
 
     onValidationChange: function()
     {
-        var validate = this.validateNode.attr("checked");
+        var validate = this.validateNode.prop("checked");
         Cookies.setCookie("validate", validate);
     },
 


### PR DESCRIPTION
Regression introduced when upgrading jQuery from  1.5.1 to 2.1.4 (209a41d0f3).

Added tests/functional/testValidateCheckbox.js to test.

jQuery blog has more info:

- http://blog.jquery.com/2011/05/10/jquery-1-6-1-rc-1-released/