### PR TITLE
For #42, Add index column to requestList

### DIFF
--- a/webapp/css/requestList.css
+++ b/webapp/css/requestList.css
@@ -69,8 +69,13 @@
     overflow: visible;
 }
 
+.netIndexCol,
 .netSizeCol {
     text-align: right;
+}
+
+.netIndexCol {
+    width: 3em;
 }
 
 .netHrefLabel {
@@ -456,6 +461,7 @@
     display: table-cell;
 }
 
+#content[previewCols~=index] TD.netIndexCol,
 #content[previewCols~=url] TD.netHrefCol,
 #content[previewCols~=status] TD.netStatusCol,
 #content[previewCols~=domain] TD.netDomainCol,

--- a/webapp/scripts/domplate/domplate.js
+++ b/webapp/scripts/domplate/domplate.js
@@ -265,9 +265,9 @@ DomplateTag.prototype =
             {
                 for (var i = 0; i < child.parts.length; ++i)
                 {
-                    if (child.parts[i] instanceof Variable)
+                    if (child.parts[i] instanceof Variables)
                     {
-                        var name = child.parts[i].name;
+                        var name = child.parts[i].names[0];
                         var names = name.split(".");
                         args.push(names[0]);
                     }
@@ -395,9 +395,9 @@ DomplateTag.prototype =
 
         fnBlock.push(blocks.join(""));
 
-        if (this.subject)
-            fnBlock.push('}\n');
         if (this.context)
+            fnBlock.push('}\n');
+        if (this.subject)
             fnBlock.push('}\n');
 
         fnBlock.push('return ', nodeCount, ';\n');
@@ -617,12 +617,25 @@ DomplateLoop.prototype = copyObject(DomplateTag.prototype,
     {
         this.addCode(topBlock, topOuts, blocks);
 
+        // We are in a FOR loop and our this.iter property contains
+        // either a simple function name as a string or a Parts object
+        // with only ONE Variables object. There is only one variables object
+        // as the FOR argument can contain only ONE valid function callback
+        // with optional arguments or just one variable. Allowed arguments are
+        // func or $var or $var.sub or $var|func or $var1,$var2|func or $var|func1|func2 or $var1,$var2|func1|func2
         var iterName;
         if (this.iter instanceof Parts)
         {
+            // We have a function with optional arguments or just one variable
             var part = this.iter.parts[0];
-            iterName = part.name;
 
+            // Join our function arguments or variables
+            // If the user has supplied multiple variables without a function
+            // this will create an invalid result and we should probably add an
+            // error message here or just take the first variable
+            iterName = part.names.join(",");
+
+            // Nest our functions
             if (part.format)
             {
                 for (var i = 0; i < part.format.length; ++i)
@@ -630,7 +643,10 @@ DomplateLoop.prototype = copyObject(DomplateTag.prototype,
             }
         }
         else
+        {
+            // We have just a simple function name without any arguments
             iterName = this.iter;
+        }
 
         blocks.push('__loop__.apply(this, [', iterName, ', __out__, function(', this.varName, ', __out__) {\n');
         this.generateChildMarkup(topBlock, topOuts, blocks, info);
@@ -685,9 +701,9 @@ DomplateLoop.prototype = copyObject(DomplateTag.prototype,
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-function Variable(name, format)
+function Variables(names, format)
 {
-    this.name = name;
+    this.names = names;
     this.format = format;
 }
 
@@ -700,7 +716,8 @@ function Parts(parts)
 
 function parseParts(str)
 {
-    var re = /\$([_A-Za-z][_A-Za-z0-9.|]*)/g;
+    // Match $var or $var.sub or $var|func or $var1,$var2|func or $var|func1|func2 or $var1,$var2|func1|func2
+    var re = /\$([_A-Za-z][_A-Za-z0-9.]*(,\$[_A-Za-z][_A-Za-z0-9.]*)*([_A-Za-z0-9.|]*))/g;
     var index = 0;
     var parts = [];
 
@@ -711,14 +728,20 @@ function parseParts(str)
         if (pre)
             parts.push(pre);
 
-        var expr = m[1].split("|");
-        parts.push(new Variable(expr[0], expr.slice(1)));
+        var segs = m[1].split("|");
+        var vars = segs[0].split(",$");
+
+        // Assemble the variables object and append to buffer
+        parts.push(new Variables(vars, segs.slice(1)));
+
         index = re.lastIndex;
     }
 
+    // No matches found at all so we return the whole string
     if (!index)
         return str;
 
+    // If we have data after our last matched index we append it here as the final step
     var post = str.substr(index);
     if (post)
         parts.push(post);
@@ -748,8 +771,8 @@ function readPartNames(val, vars)
         for (var i = 0; i < val.parts.length; ++i)
         {
             var part = val.parts[i];
-            if (part instanceof Variable)
-                vars.push(part.name);
+            if (part instanceof Variables)
+                vars.push(part.names[0]);
         }
     }
 }
@@ -762,7 +785,7 @@ function generateArg(val, path, args)
         for (var i = 0; i < val.parts.length; ++i)
         {
             var part = val.parts[i];
-            if (part instanceof Variable)
+            if (part instanceof Variables)
             {
                 var varName = 'd'+path.renderIndex++;
                 if (part.format)
@@ -794,9 +817,11 @@ function addParts(val, delim, block, info, escapeIt)
         for (var i = 0; i < val.parts.length; ++i)
         {
             var part = val.parts[i];
-            if (part instanceof Variable)
+            if (part instanceof Variables)
             {
-                var partName = part.name;
+                // Only grap one variable.
+                // This is fine as we are not passing it to a function and only displaying it.
+                var partName = part.names.join(",");
                 if (part.format)
                 {
                     for (var j = 0; j < part.format.length; ++j)
@@ -1098,6 +1123,9 @@ defineTags(
     "span", "strong", "table", "tbody", "td", "textarea", "tfoot", "th", "thead", "tr", "tt", "ul", "code",
     "iframe", "canvas"
 );
+
+// export StopIteration so custom iterators can use it
+this.StopIteration = StopIteration;
 
 }).apply(Domplate);
 

--- a/webapp/scripts/nls/pageList.js
+++ b/webapp/scripts/nls/pageList.js
@@ -3,6 +3,7 @@
 define(
 {
     "root": {
+        "column.label.index": "Index",
         "column.label.url": "URL",
         "column.label.status": "Status",
         "column.label.type": "Type",

--- a/webapp/scripts/preview/harModel.js
+++ b/webapp/scripts/preview/harModel.js
@@ -51,7 +51,7 @@ HarModel.prototype =
                 return 1;
 
             return 0;
-        })
+        });
 
         if (this.input)
         {
@@ -85,10 +85,7 @@ HarModel.prototype =
      */
     getPages: function()
     {
-        if (!this.input)
-            return [];
-
-        return this.input.log.pages ? this.input.log.pages : [];
+        return HarModel.getPages(this.input);
     },
 
     /**
@@ -235,6 +232,31 @@ HarModel.parse = function(jsonString, validate)
     throw result;
 };
 
+HarModel.getPages = function(input)
+{
+    if (!input)
+        return [];
+
+    return input.log.pages ? input.log.pages : [];
+};
+
+HarModel.getPageIndex = function(input, page)
+{
+    if (!page || !page.id)
+    {
+        throw { errors: ["page must exist and have an id"], input: input };
+    }
+    var pages = HarModel.getPages(input);
+    for (var i = 0; i < pages.length; i++)
+    {
+        if (page.id === pages[i].id)
+        {
+            return i;
+        }
+    }
+    return -1;
+};
+
 // xxxHonza: optimalization using a map?
 /**
  * If `page` is not provided, then return all the HAR entries without a parent `Page`.
@@ -348,7 +370,7 @@ HarModel.validateRequestTimings = function(input)
 
     if (errors.length)
         throw {errors: errors, input: input};
-}
+};
 
 HarModel.isCachedEntry = function(entry) {
     var response = entry.response;


### PR DESCRIPTION
Hi, this PR is a tentative step to adding an index column to `RequestList`.  I say tentative because I'm still not totally familiar with domplate, so I could be using it inappropriately.

Would appreciate any comments and tips. Cheers!

---

The index can be output in one of two formats:
- "page" - index is composite of page number and entry number.
  e.g. "1.1", "1.2", ... "2.1", "2.2", etc.
- "entry" - index is simple, flat index.
  e.g. "1", "2", etc.

The index type is passed to the `RequestList` constructor in an options object.

This change needed to pass multiple arguments to domplate callbacks, so
cherry-picked domplate.js changes from:
- https://github.com/firebug/firebug/commit/65d035b7814c82e5e3a9fa2a145c5117bb290f79
  (Issue 5107: Passing multiple arguments to a function in Domplate)

---

Sample:

![harviewer-42](https://cloud.githubusercontent.com/assets/1020541/10150630/6468367c-6638-11e5-911a-4d8c8a688b95.png)
