### PR TITLE
Add Nashorn for Java builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Components
 
 Build Tools
 -----------
+* Java 8 (for [Nashorn/jjs](http://docs.oracle.com/javase/8/docs/technotes/tools/windows/jjs.html) build)
 * Ant: http://ant.apache.org/
 * js-build-tools: http://code.google.com/p/js-build-tools/
 * js-min (ant task): http://code.google.com/p/jsmin-ant-task/
@@ -40,12 +41,35 @@ Testing
 
 Development
 -----------
+
+A build can be performed in one of three ways.
+
+### 1) Node.js
+
+This is the default and preferred method.  Node.js must be installed.
 To start a build, go to the project directory and execute the following command:
 
 `ant build`
 
-This default build requires Node.js to be installed (the preferred option).
+(*Indicative build time - about 9 seconds.  Node.js v6.0.0*)
 
-For a Java-only build (not the preferred option), execute the following command:
+### 2) Java 8 / Nashorn
+
+To build using the [jjs](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/jjs.html) command, Java 8 must be installed.
+Execute the following command:
+
+`ant -Drjs.runner=nashorn build`
+
+(*Indicative build time - about 1 minute 37 seconds.  nashorn 1.8.0_92*)
+
+### 3) Pre-Java 8 / Rhino
+
+To build using Java 7 or earlier, execute the following command:
 
 `ant -Drjs.runner=java build`
+
+You will have to set the [optimize build configuration value](https://github.com/janodvarko/harviewer/blob/0997957b3ecb9fbdb27df4260d5bc85c653fac81/webapp/scripts/app.build.js#L11) to `"closure"`, for example:
+
+     optimize: "closure",
+
+(*Indicative build time - about 42 seconds*)

--- a/build.xml
+++ b/build.xml
@@ -117,15 +117,20 @@
             <matches pattern="^node$" string="${rjs.runner}"/>
         </condition>
 
+        <condition property="rjs.runner.isNashorn">
+            <matches pattern="^nashorn$" string="${rjs.runner}"/>
+        </condition>
+
         <condition property="rjs.runner.isJava">
             <matches pattern="^java$" string="${rjs.runner}"/>
         </condition>
 
-        <fail message="Ant property 'rjs.runner' must be set to either 'node' (the default) or 'java'. Value was '${rjs.runner}'.">
+        <fail message="Ant property 'rjs.runner' must be set to either 'node' (the default), 'nashorn' or 'java'. Value was '${rjs.runner}'.">
             <condition>
                 <not>
                     <or>
                         <isset property="rjs.runner.isNode"/>
+                        <isset property="rjs.runner.isNashorn"/>
                         <isset property="rjs.runner.isJava"/>
                     </or>
                 </not>
@@ -141,6 +146,16 @@
     <target name="rjs-node" depends="rjs-determine-runner" if="rjs.runner.isNode">
         <exec dir="${app.dir}/scripts" executable="node" resolveexecutable="true">
             <arg value="${rjs.cmd}"/>
+            <arg value="-o"/>
+            <arg value="app.build.js"/>
+        </exec>
+    </target>
+
+    <target name="rjs-nashorn" depends="rjs-determine-runner" if="rjs.runner.isNashorn">
+        <exec dir="${app.dir}/scripts" executable="jjs" resolveexecutable="true">
+            <arg value="-scripting"/>
+            <arg value="${rjs.cmd}"/>
+            <arg value="--"/>
             <arg value="-o"/>
             <arg value="app.build.js"/>
         </exec>
@@ -163,7 +178,7 @@
 
 
     <!-- Build HAR Viewer package (the result is within build.dir) -->
-    <target name="build" depends="rjs-java, rjs-node">
+    <target name="build" depends="rjs-java, rjs-node, rjs-nashorn">
 
         <!-- Log info about the current OS -->
         <echo message="Building HAR Viewer on:" />


### PR DESCRIPTION
See https://github.com/requirejs/r.js/commit/1271aa77232ba0b5e64d3c114a88a6b0a91dfc9a

References:

- [*uglify.js is slow with Nashorn (mostly looks like wasting time recalculating getters/setters and slow JSON parsing)*]
(https://bugs.openjdk.java.net/browse/JDK-8067764)

- [*Compressed/mangled code is slower onto Nashorn javascript engine*]
(https://github.com/mishoo/UglifyJS2/issues/811)

- [*node.js vs Java nashorn*]
(http://pieroxy.net/blog/2015/06/29/node_js_vs_java_nashorn.html)

Fixes #69