### PR TITLE
Only show postData when it's valid

### DIFF
--- a/selenium/tests/hars/issue-21/get-empty-post-data.har
+++ b/selenium/tests/hars/issue-21/get-empty-post-data.har
@@ -1,0 +1,171 @@
+{
+  "log": {
+    "version": "1.1",
+    "creator": {
+      "name": "Firefox",
+      "version": "47.0"
+    },
+    "browser": {
+      "name": "Firefox",
+      "version": "47.0"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-06-22T07:37:51.115+01:00",
+        "id": "page_1",
+        "title": "Tags and Attributes | React",
+        "pageTimings": {
+          "onContentLoad": -1,
+          "onLoad": -1
+        }
+      }
+    ],
+    "entries": [
+      {
+        "pageref": "page_1",
+        "startedDateTime": "2016-06-22T07:37:51.115+01:00",
+        "time": 431,
+        "request": {
+          "bodySize": 0,
+          "method": "GET",
+          "url": "https://facebook.github.io/react/docs/tags-and-attributes.html",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Host",
+              "value": "facebook.github.io"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0"
+            },
+            {
+              "name": "Accept",
+              "value": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-GB,en;q=0.5"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, br"
+            },
+            {
+              "name": "Cookie",
+              "value": "_ga=GA1.3.1225554301.1466577468; _gat=1"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "no-cache"
+            }
+          ],
+          "cookies": [
+            {
+              "name": "_ga",
+              "value": "GA1.3.1225554301.1466577468"
+            },
+            {
+              "name": "_gat",
+              "value": "1"
+            }
+          ],
+          "queryString": [],
+          "postData": {
+            "mimeType": "",
+            "params": [],
+            "text": ""
+          },
+          "headersSize": 428
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Server",
+              "value": "GitHub.com"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Tue, 21 Jun 2016 03:25:11 GMT"
+            },
+            {
+              "name": "Access-Control-Allow-Origin",
+              "value": "*"
+            },
+            {
+              "name": "Expires",
+              "value": "Wed, 22 Jun 2016 06:36:19 GMT"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "max-age=600"
+            },
+            {
+              "name": "Content-Encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "Content-Length",
+              "value": "7173"
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "Date",
+              "value": "Wed, 22 Jun 2016 06:37:52 GMT"
+            },
+            {
+              "name": "Via",
+              "value": "1.1 varnish"
+            },
+            {
+              "name": "Age",
+              "value": "581"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "mimeType": "text/html; charset=utf-8",
+            "size": 22598,
+            "text": "Content and some headers removed from HAR to save space"
+          },
+          "redirectURL": "",
+          "headersSize": 584,
+          "bodySize": 7173
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0,
+          "dns": 1,
+          "connect": 148,
+          "send": 139,
+          "wait": 141,
+          "receive": 2
+        },
+        "serverIPAddress": "151.101.56.133",
+        "connection": "443"
+      }
+    ]
+  }
+}

--- a/selenium/tests/hars/issue-21/post-empty-post-data.har
+++ b/selenium/tests/hars/issue-21/post-empty-post-data.har
@@ -1,0 +1,171 @@
+{
+  "log": {
+    "version": "1.1",
+    "creator": {
+      "name": "Firefox",
+      "version": "47.0"
+    },
+    "browser": {
+      "name": "Firefox",
+      "version": "47.0"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-06-22T07:37:51.115+01:00",
+        "id": "page_1",
+        "title": "Tags and Attributes | React",
+        "pageTimings": {
+          "onContentLoad": -1,
+          "onLoad": -1
+        }
+      }
+    ],
+    "entries": [
+      {
+        "pageref": "page_1",
+        "startedDateTime": "2016-06-22T07:37:51.115+01:00",
+        "time": 431,
+        "request": {
+          "bodySize": 0,
+          "method": "POST",
+          "url": "https://facebook.github.io/react/docs/tags-and-attributes.html",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Host",
+              "value": "facebook.github.io"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0"
+            },
+            {
+              "name": "Accept",
+              "value": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-GB,en;q=0.5"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, br"
+            },
+            {
+              "name": "Cookie",
+              "value": "_ga=GA1.3.1225554301.1466577468; _gat=1"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "no-cache"
+            }
+          ],
+          "cookies": [
+            {
+              "name": "_ga",
+              "value": "GA1.3.1225554301.1466577468"
+            },
+            {
+              "name": "_gat",
+              "value": "1"
+            }
+          ],
+          "queryString": [],
+          "postData": {
+            "mimeType": "",
+            "params": [],
+            "text": ""
+          },
+          "headersSize": 428
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Server",
+              "value": "GitHub.com"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Tue, 21 Jun 2016 03:25:11 GMT"
+            },
+            {
+              "name": "Access-Control-Allow-Origin",
+              "value": "*"
+            },
+            {
+              "name": "Expires",
+              "value": "Wed, 22 Jun 2016 06:36:19 GMT"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "max-age=600"
+            },
+            {
+              "name": "Content-Encoding",
+              "value": "gzip"
+            },
+            {
+              "name": "Content-Length",
+              "value": "7173"
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "Date",
+              "value": "Wed, 22 Jun 2016 06:37:52 GMT"
+            },
+            {
+              "name": "Via",
+              "value": "1.1 varnish"
+            },
+            {
+              "name": "Age",
+              "value": "581"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "mimeType": "text/html; charset=utf-8",
+            "size": 22598,
+            "text": "Content and some headers removed from HAR to save space"
+          },
+          "redirectURL": "",
+          "headersSize": 584,
+          "bodySize": 7173
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0,
+          "dns": 1,
+          "connect": 148,
+          "send": 139,
+          "wait": 141,
+          "receive": 2
+        },
+        "serverIPAddress": "151.101.56.133",
+        "connection": "443"
+      }
+    ]
+  }
+}

--- a/webapp/scripts/nls/requestBody.js
+++ b/webapp/scripts/nls/requestBody.js
@@ -11,6 +11,7 @@ define(
         "Headers": "Headers",
         "Post": "Post",
         "Put": "Put",
+        "Get": "Get",
         "Cookies": "Cookies",
         "Response": "Response",
         "Cache": "Cache",


### PR DESCRIPTION
Firefox 47 (at least) exports GET requests in HARs that have:

          "postData": {
            "mimeType": "",
            "params": [],
            "text": ""
          },

So the new code looks out for this.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1174095.

Fixes #21