### PR TITLE
Responses with status==0 are requestList errors

### DIFF
--- a/selenium/tests/hars/issue-49/chrome51.har
+++ b/selenium/tests/hars/issue-49/chrome51.har
@@ -1,0 +1,280 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-06-15T21:38:04.831Z",
+        "id": "page_5",
+        "title": "issue-49.chrome51",
+        "pageTimings": {
+          "onContentLoad": 388.1240000046091,
+          "onLoad": 387.94400000188034
+        }
+      }
+    ],
+    "entries": [
+      {
+        "startedDateTime": "2016-06-15T21:38:04.831Z",
+        "time": 18.67800000036368,
+        "request": {
+          "method": "GET",
+          "url": "http://localhost:8888/harviewer-49.html",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "Host",
+              "value": "localhost:8888"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-GB,en-US;q=0.8,en;q=0.6"
+            },
+            {
+              "name": "Upgrade-Insecure-Requests",
+              "value": "1"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36"
+            },
+            {
+              "name": "Accept",
+              "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "max-age=0"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 426,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Wed, 15 Jun 2016 21:38:04 GMT"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "ETag",
+              "value": "9245bd0b"
+            },
+            {
+              "name": "Content-Length",
+              "value": "287"
+            },
+            {
+              "name": "Content-Length",
+              "value": "287"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/html"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 287,
+            "mimeType": "text/html",
+            "compression": -1
+          },
+          "redirectURL": "",
+          "headersSize": 185,
+          "bodySize": 288,
+          "_transferSize": 473
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 9.51200000417884,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.3089999954681897,
+          "wait": 7.232000003568869,
+          "receive": 1.624999997147782,
+          "ssl": -1
+        },
+        "serverIPAddress": "127.0.0.1",
+        "connection": "37299",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-06-15T21:38:04.981Z",
+        "time": 0,
+        "request": {
+          "method": "GET",
+          "url": "https://expired.badssl.com/style.css",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "Referer",
+              "value": "http://localhost:8888/harviewer-49.html"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 0,
+          "statusText": "",
+          "httpVersion": "unknown",
+          "headers": [],
+          "cookies": [],
+          "content": {
+            "size": 0,
+            "mimeType": "x-unknown"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 0,
+          "_error": "net::ERR_INSECURE_RESPONSE"
+        },
+        "cache": {},
+        "timings": {
+          "blocked": -1,
+          "dns": -1,
+          "connect": -1,
+          "send": 0,
+          "wait": 0,
+          "receive": 0,
+          "ssl": -1
+        },
+        "serverIPAddress": "",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-06-15T21:38:04.981Z",
+        "time": 0,
+        "request": {
+          "method": "GET",
+          "url": "https://wrong.host.badssl.com/style.css",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "Referer",
+              "value": "http://localhost:8888/harviewer-49.html"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 0,
+          "statusText": "",
+          "httpVersion": "unknown",
+          "headers": [],
+          "cookies": [],
+          "content": {
+            "size": 0,
+            "mimeType": "x-unknown"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 0,
+          "_error": "net::ERR_INSECURE_RESPONSE"
+        },
+        "cache": {},
+        "timings": {
+          "blocked": -1,
+          "dns": -1,
+          "connect": -1,
+          "send": 0,
+          "wait": 0,
+          "receive": 0,
+          "ssl": -1
+        },
+        "serverIPAddress": "",
+        "pageref": "page_5"
+      },
+      {
+        "startedDateTime": "2016-06-15T21:38:04.982Z",
+        "time": 0,
+        "request": {
+          "method": "GET",
+          "url": "http://native.sharethrough.com/assets/sfp.js",
+          "httpVersion": "unknown",
+          "headers": [
+            {
+              "name": "Referer",
+              "value": "http://localhost:8888/harviewer-49.html"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.84 Safari/537.36"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": -1,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 0,
+          "statusText": "",
+          "httpVersion": "unknown",
+          "headers": [],
+          "cookies": [],
+          "content": {
+            "size": 0,
+            "mimeType": "x-unknown"
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1,
+          "_transferSize": 0,
+          "_error": "net::ERR_BLOCKED_BY_CLIENT"
+        },
+        "cache": {},
+        "timings": {
+          "blocked": -1,
+          "dns": -1,
+          "connect": -1,
+          "send": 0,
+          "wait": 0,
+          "receive": 0,
+          "ssl": -1
+        },
+        "serverIPAddress": "",
+        "pageref": "page_5"
+      }
+    ]
+  }
+}

--- a/selenium/tests/hars/issue-49/ff47.har
+++ b/selenium/tests/hars/issue-49/ff47.har
@@ -1,0 +1,302 @@
+{
+  "log": {
+    "version": "1.1",
+    "creator": {
+      "name": "Firefox",
+      "version": "47.0"
+    },
+    "browser": {
+      "name": "Firefox",
+      "version": "47.0"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-06-15T22:35:41.213+01:00",
+        "id": "page_3",
+        "title": "issue-49.ff47",
+        "pageTimings": {
+          "onContentLoad": -1,
+          "onLoad": -1
+        }
+      }
+    ],
+    "entries": [
+      {
+        "pageref": "page_3",
+        "startedDateTime": "2016-06-15T22:35:41.213+01:00",
+        "time": 0,
+        "request": {
+          "bodySize": 0,
+          "method": "GET",
+          "url": "http://localhost:8888/harviewer-49.html",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Host",
+              "value": "localhost:8888"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0"
+            },
+            {
+              "name": "Accept",
+              "value": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-GB,en;q=0.5"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "no-cache"
+            }
+          ],
+          "cookies": [],
+          "queryString": [],
+          "postData": {
+            "mimeType": "",
+            "params": [],
+            "text": ""
+          },
+          "headersSize": 353
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK ",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Content-Length",
+              "value": "287"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/html"
+            },
+            {
+              "name": "Date",
+              "value": "Wed, 15 Jun 2016 21:35:41 GMT"
+            },
+            {
+              "name": "Etag",
+              "value": "9245bd0b"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "mimeType": "text/html",
+            "size": 287,
+            "text": "<!doctype html>\r\n\r\n<head>\r\n\r\n<link type=\"text/css\" rel=\"stylesheet\" href=\"https://expired.badssl.com/style.css\">\r\n\r\n<link type=\"text/css\" rel=\"stylesheet\" href=\"https://wrong.host.badssl.com/style.css\">\r\n\r\n<script src=\"http://native.sharethrough.com/assets/sfp.js\"></script>\r\n\r\n</head>\r\n"
+          },
+          "redirectURL": "",
+          "headersSize": 165,
+          "bodySize": 287
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0,
+          "dns": 0,
+          "connect": 0,
+          "send": 0,
+          "wait": 0,
+          "receive": 0
+        },
+        "serverIPAddress": "127.0.0.1",
+        "connection": "8888"
+      },
+      {
+        "pageref": "page_3",
+        "startedDateTime": "2016-06-15T22:35:41.260+01:00",
+        "time": 0,
+        "request": {
+          "bodySize": 0,
+          "method": "GET",
+          "url": "https://expired.badssl.com/style.css",
+          "httpVersion": "",
+          "headers": [
+            {
+              "name": "Host",
+              "value": "expired.badssl.com"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0"
+            },
+            {
+              "name": "Accept",
+              "value": "text/css,*/*;q=0.1"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-GB,en;q=0.5"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, br"
+            },
+            {
+              "name": "Referer",
+              "value": "http://localhost:8888/harviewer-49.html"
+            },
+            {
+              "name": "DNT",
+              "value": "1"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "no-cache"
+            }
+          ],
+          "cookies": [],
+          "queryString": [],
+          "postData": {
+            "mimeType": "",
+            "params": [],
+            "text": ""
+          },
+          "headersSize": 366
+        },
+        "response": {
+          "status": 0,
+          "statusText": "",
+          "httpVersion": "",
+          "headers": [],
+          "cookies": [],
+          "content": {
+            "mimeType": "text/plain",
+            "size": 0,
+            "encoding": "base64",
+            "text": ""
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0,
+          "dns": 0,
+          "connect": 0,
+          "send": 0,
+          "wait": 0,
+          "receive": 0
+        }
+      },
+      {
+        "pageref": "page_3",
+        "startedDateTime": "2016-06-15T22:35:41.260+01:00",
+        "time": 125,
+        "request": {
+          "bodySize": 0,
+          "method": "GET",
+          "url": "https://wrong.host.badssl.com/style.css",
+          "httpVersion": "",
+          "headers": [
+            {
+              "name": "Host",
+              "value": "wrong.host.badssl.com"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0"
+            },
+            {
+              "name": "Accept",
+              "value": "text/css,*/*;q=0.1"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-GB,en;q=0.5"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, br"
+            },
+            {
+              "name": "Referer",
+              "value": "http://localhost:8888/harviewer-49.html"
+            },
+            {
+              "name": "DNT",
+              "value": "1"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "no-cache"
+            }
+          ],
+          "cookies": [],
+          "queryString": [],
+          "postData": {
+            "mimeType": "",
+            "params": [],
+            "text": ""
+          },
+          "headersSize": 369
+        },
+        "response": {
+          "status": 0,
+          "statusText": "",
+          "httpVersion": "",
+          "headers": [],
+          "cookies": [],
+          "content": {
+            "mimeType": "text/plain",
+            "size": 0,
+            "encoding": "base64",
+            "text": ""
+          },
+          "redirectURL": "",
+          "headersSize": -1,
+          "bodySize": -1
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0,
+          "dns": 16,
+          "connect": 109,
+          "send": 0,
+          "wait": 0,
+          "receive": 0
+        }
+      }
+    ]
+  }
+}

--- a/webapp/scripts/preview/requestList.js
+++ b/webapp/scripts/preview/requestList.js
@@ -43,7 +43,7 @@ function RequestList(input)
 }
 
 // ********************************************************************************************* //
-// Columns 
+// Columns
 
 /**
  * List of all available columns for the request table, see also RequestList.prototype.tableTag
@@ -121,7 +121,7 @@ RequestList.setVisibleColumns();
 
 /**
  * @domplate This object represents a template for list of entries (requests).
- * This list is displayed when a page is expanded by the user. 
+ * This list is displayed when a page is expanded by the user.
  */
 RequestList.prototype = domplate(
 /** @lends RequestList */
@@ -237,8 +237,8 @@ RequestList.prototype = domplate(
 
     isError: function(file)
     {
-        var errorRange = Math.floor(file.response.status/100);
-        return errorRange == 4 || errorRange == 5;
+        var errorRange = Math.floor(file.response.status / 100);
+        return errorRange === 4 || errorRange === 5 || errorRange === 0;
     },
 
     isRedirect: function(file)
@@ -267,8 +267,14 @@ RequestList.prototype = domplate(
 
     getStatus: function(file)
     {
-        var status = file.response.status > 0 ? (file.response.status + " ") : "";
-        return status + file.response.statusText;
+        // WebInspector can include an _error property when response.status===0.
+        // Use this _error value if provided, as it's more informative than showing '0'.
+        if (file.response.status === 0 && file.response._error) {
+            return file.response._error;
+        } else {
+            var status = file.response.status > 0 ? (file.response.status + " ") : "";
+            return status + file.response.statusText;
+        }
     },
 
     getType: function(file)
@@ -599,9 +605,9 @@ RequestList.prototype = domplate(
         var startedDateTime = Lib.parseISO8601(file.startedDateTime);
         this.barOffset = (((startedDateTime-this.phaseStartTime)/this.phaseElapsed) * 100).toFixed(3);
 
-        // Compute size of each bar. Left side of each bar starts at the 
+        // Compute size of each bar. Left side of each bar starts at the
         // beginning. The first bar is on top of all and the last one is
-        // at the bottom (z-index). 
+        // at the bottom (z-index).
         this.barBlockingWidth = ((blocking/this.phaseElapsed) * 100).toFixed(3);
         this.barResolvingWidth = ((resolving/this.phaseElapsed) * 100).toFixed(3);
         this.barConnectingWidth = ((connecting/this.phaseElapsed) * 100).toFixed(3);
@@ -643,7 +649,7 @@ RequestList.prototype = domplate(
 
         var phase;
 
-        // Iterate over all existing entries. Some rows aren't associated with a file 
+        // Iterate over all existing entries. Some rows aren't associated with a file
         // (e.g. header, sumarry) so, skip them.
         for (var row = this.firstRow; row; row = row.nextSibling)
         {
@@ -675,11 +681,11 @@ RequestList.prototype = domplate(
             var waitingBar = sendingBar.nextSibling;
             var receivingBar = waitingBar.nextSibling;
 
-            // All bars starts at the beginning of the appropriate request graph. 
-            blockingBar.style.left = 
+            // All bars starts at the beginning of the appropriate request graph.
+            blockingBar.style.left =
                 connectingBar.style.left =
                 resolvingBar.style.left =
-                sendingBar.style.left = 
+                sendingBar.style.left =
                 waitingBar.style.left =
                 receivingBar.style.left = this.barOffset + "%";
 


### PR DESCRIPTION
HAR files `selenium/tests/hars/issue-49/chrome51.har` and `selenium/tests/hars/issue-49/ff47.har`
show examples of Chrome and Firefox response errors.

response.status==0 is now treated as an error, like 4xx and 5xx responses.

Fixes #49.