### PR TITLE
X firefox geckodriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Testing
 Development
 -----------
 
+The HAR Viewer build process uses Ant as its build tool.  To see a list of available tasks, use `ant -p` at the command line.
+
 A build can be performed in one of three ways.
 
 ### 1) Node.js

--- a/build.xml
+++ b/build.xml
@@ -26,6 +26,9 @@
     <property name="chromedriver.version" value="2.21"/>
     <property name="chromedriver.filename" value="chromedriver_win32.zip"/>
     <property name="chromedriver.url" value="http://chromedriver.storage.googleapis.com/${chromedriver.version}/${chromedriver.filename}"/>
+    <property name="geckodriver.version" value="0.8.0"/>
+    <property name="geckodriver.filename" value="geckodriver-v${geckodriver.version}-win32.zip"/>
+    <property name="geckodriver.url" value="https://github.com/mozilla/geckodriver/releases/download/v${geckodriver.version}/${geckodriver.filename}"/>
 
     <!-- Tools for building release package of HAR Viewer.
         js-build-tools: http://code.google.com/p/js-build-tools/
@@ -61,7 +64,7 @@
     <!--
     Downloads selenium server.  Selenium server is required for testing.
     -->
-    <target name="get-iedriver">
+    <target name="get-iedriver" description="Downloads IEDriver">
         <property name="iedriver.dir" value="${basedir}/selenium/iedriver"/>
         <mkdir dir="${iedriver.dir}"/>
         <get dest="${iedriver.dir}" verbose="true">
@@ -70,7 +73,7 @@
         <unzip src="${iedriver.dir}/${iedriver.filename}" dest="${basedir}/selenium"/>
     </target>
 
-    <target name="get-chromedriver">
+    <target name="get-chromedriver" description="Downloads ChromeDriver">
         <property name="chromedriver.dir" value="${basedir}/selenium/chromedriver"/>
         <mkdir dir="${chromedriver.dir}"/>
         <get dest="${chromedriver.dir}" verbose="true">
@@ -79,7 +82,16 @@
         <unzip src="${chromedriver.dir}/${chromedriver.filename}" dest="${basedir}/selenium"/>
     </target>
 
-    <target name="get-selenium" depends="get-iedriver, get-chromedriver">
+    <target name="get-geckodriver" description="Downloads GeckoDriver">
+        <property name="geckodriver.dir" value="${basedir}/selenium/geckodriver"/>
+        <mkdir dir="${geckodriver.dir}"/>
+        <get dest="${geckodriver.dir}" verbose="true">
+            <url url="${geckodriver.url}" />
+        </get>
+        <unzip src="${geckodriver.dir}/${geckodriver.filename}" dest="${basedir}/selenium"/>
+    </target>
+
+    <target name="get-selenium" depends="get-iedriver, get-chromedriver, get-geckodriver" description="Downloads Selenium and IE/Chrome/Gecko drivers">
         <get src="${selenium.server.url}" dest="${basedir}/selenium/server/selenium-server.jar" verbose="true"/>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -52,7 +52,7 @@
         classpathref="js-build-tasks.classpath"/>
 
     <!-- Remove the previous HAR Viewer build. -->
-    <target name="clean">
+    <target name="clean" description="Cleans the webapp and jsdoc build folders">
         <delete dir="${build.dir}"/>
         <delete dir="${jsdoc.build.dir}"/>
     </target>
@@ -64,7 +64,7 @@
     <!--
     Downloads selenium server.  Selenium server is required for testing.
     -->
-    <target name="get-iedriver" description="Downloads IEDriver">
+    <target name="get-iedriver" description="Downloads IEDriver and makes it available to the start-server.bat command">
         <property name="iedriver.dir" value="${basedir}/selenium/iedriver"/>
         <mkdir dir="${iedriver.dir}"/>
         <get dest="${iedriver.dir}" verbose="true">
@@ -73,7 +73,7 @@
         <unzip src="${iedriver.dir}/${iedriver.filename}" dest="${basedir}/selenium"/>
     </target>
 
-    <target name="get-chromedriver" description="Downloads ChromeDriver">
+    <target name="get-chromedriver" description="Downloads ChromeDriver and makes it available to the start-server.bat command">
         <property name="chromedriver.dir" value="${basedir}/selenium/chromedriver"/>
         <mkdir dir="${chromedriver.dir}"/>
         <get dest="${chromedriver.dir}" verbose="true">
@@ -82,7 +82,7 @@
         <unzip src="${chromedriver.dir}/${chromedriver.filename}" dest="${basedir}/selenium"/>
     </target>
 
-    <target name="get-geckodriver" description="Downloads GeckoDriver">
+    <target name="get-geckodriver" description="Downloads GeckoDriver and makes it available to the start-server.bat command">
         <property name="geckodriver.dir" value="${basedir}/selenium/geckodriver"/>
         <mkdir dir="${geckodriver.dir}"/>
         <get dest="${geckodriver.dir}" verbose="true">
@@ -91,7 +91,7 @@
         <unzip src="${geckodriver.dir}/${geckodriver.filename}" dest="${basedir}/selenium"/>
     </target>
 
-    <target name="get-selenium" depends="get-iedriver, get-chromedriver, get-geckodriver" description="Downloads Selenium and IE/Chrome/Gecko drivers">
+    <target name="get-selenium" depends="get-iedriver, get-chromedriver, get-geckodriver" description="Downloads Selenium and IE/Chrome/Gecko drivers and makes them available to the start-server.bat command">
         <get src="${selenium.server.url}" dest="${basedir}/selenium/server/selenium-server.jar" verbose="true"/>
     </target>
 
@@ -190,7 +190,7 @@
 
 
     <!-- Build HAR Viewer package (the result is within build.dir) -->
-    <target name="build" depends="rjs-java, rjs-node, rjs-nashorn">
+    <target name="build" depends="rjs-java, rjs-node, rjs-nashorn" description="Builds HAR Viewer">
 
         <!-- Log info about the current OS -->
         <echo message="Building HAR Viewer on:" />
@@ -226,7 +226,7 @@
     </target>
 
     <!-- Build HAR Viewer package (the result is within build.dir) -->
-    <target name="clean-build" depends="clean, build">
+    <target name="clean-build" depends="clean, build" description="Calls the clean task then performs a build">
     </target>
 
     <!-- Support for generating docs from Firebug source code using npm jsdoc

--- a/selenium/start-server.bat
+++ b/selenium/start-server.bat
@@ -1,18 +1,20 @@
 REM Assumes IEDriverServer.exe and chromedriver.exe are in the same folder as this batch file.
 
-set          FIREFOX_EXE=c:\Program Files\Mozilla Firefox\firefox.exe
+set          FIREFOX_EXE=c:\apps\Mozilla Firefox\46\firefox.exe
 set        IE_DRIVER_EXE=%~dp0IEDriverServer.exe
 set    CHROME_DRIVER_EXE=%~dp0chromedriver.exe
 set        PHANTOMJS_EXE=c:\apps\phantomjs\2.1.1\bin\phantomjs.exe
+set     GECKO_DRIVER_EXE=%~dp0geckodriver.exe
 
 set    CHROME_DRIVER_ARG=-Dwebdriver.chrome.driver="%CHROME_DRIVER_EXE%"
 set        IE_DRIVER_ARG=-Dwebdriver.ie.driver="%IE_DRIVER_EXE%"
 set   FIREFOX_DRIVER_ARG=-Dwebdriver.firefox.bin="%FIREFOX_EXE%"
 set PHANTOMJS_DRIVER_ARG=-Dphantomjs.binary.path="%PHANTOMJS_EXE%"
+set     GECKO_DRIVER_ARG=-Dwebdriver.gecko.driver="%GECKO_DRIVER_EXE%"
 
-set  FIREFOX_PROFILE_ARG=-Dwebdriver.firefox.profile=selenium
+set  FIREFOX_PROFILE_ARG=-Dwebdriver.firefox.profile=ff46-selenium
 
-set DRIVER_ARGS=%FIREFOX_DRIVER_ARG% %CHROME_DRIVER_ARG% %IE_DRIVER_ARG% %PHANTOMJS_DRIVER_ARG% %FIREFOX_PROFILE_ARG%
+set DRIVER_ARGS=%FIREFOX_DRIVER_ARG% %CHROME_DRIVER_ARG% %IE_DRIVER_ARG% %PHANTOMJS_DRIVER_ARG% %GECKO_DRIVER_ARG% %FIREFOX_PROFILE_ARG%
 
 REM java -jar server/selenium-server.jar -debug
 java -jar %~dp0server\selenium-server.jar %DRIVER_ARGS% -debug

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,7 +25,7 @@ Start a web server from the project root, and browse to Intern's "client.html" p
 
 The Selenium tests require [Selenium](http://www.seleniumhq.org/download/) and Intern to be installed.
 
-Download Selenium by running the following Ant command from the project root.
+Download Selenium (and the IE/Chrome/Gecko drivers) by running the following Ant command from the project root.
 
     ant get-selenium
 


### PR DESCRIPTION
Add download task for geckodriver, but the tests continue to use FF46 and the old driver until the Selenium/geckodriver combo is stable.