### PR TITLE
Syntax highlighting for HTML, CSS, XML and JSON

### DIFF
--- a/selenium/tests/hars/issue-78/css.har
+++ b/selenium/tests/hars/issue-78/css.har
@@ -1,0 +1,132 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-06-25T07:18:57.500Z",
+        "id": "page_1",
+        "title": "CSS",
+        "pageTimings": {
+          "onContentLoad": 276.01199999980963,
+          "onLoad": 275.79100000002654
+        }
+      }
+    ],
+    "entries": [
+      {
+        "startedDateTime": "2016-06-25T07:18:57.500Z",
+        "time": 25.965000000724103,
+        "request": {
+          "method": "GET",
+          "url": "http://harviewer:49001/webapp/css/dragdrop.css",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "Host",
+              "value": "harviewer:49001"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-GB,en-US;q=0.8,en;q=0.6"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"
+            },
+            {
+              "name": "Accept",
+              "value": "text/css,*/*;q=0.1"
+            },
+            {
+              "name": "Referer",
+              "value": "http://harviewer:49001/webapp/?path=/selenium/tests/hars/issue-78/css.har"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "no-cache"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 530,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Sat, 25 Jun 2016 10:16:07 GMT"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Tue, 02 Jun 2015 06:52:17 GMT"
+            },
+            {
+              "name": "Server",
+              "value": "Apache-Coyote/1.1"
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "ETag",
+              "value": "W/\"176-1433227937851\""
+            },
+            {
+              "name": "Content-Length",
+              "value": "176"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/css"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 176,
+            "mimeType": "text/css",
+            "compression": 0,
+            "text": "/* See license.txt for terms of usage */\r\n\r\nbody[vResizing=\"true\"] * {\r\n    cursor: e-resize !important;\r\n}\r\n\r\nbody[hResizing=\"true\"] * {\r\n    cursor: s-resize !important;\r\n}\r\n"
+          },
+          "redirectURL": "",
+          "headersSize": 225,
+          "bodySize": 176,
+          "_transferSize": 401
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 21.759999999631,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.20600000061670087,
+          "wait": 1.3010000002396005,
+          "receive": 2.698000000236803,
+          "ssl": -1
+        },
+        "serverIPAddress": "192.168.1.80",
+        "connection": "12431",
+        "pageref": "page_1"
+      }
+    ]
+  }
+}

--- a/selenium/tests/hars/issue-78/html.har
+++ b/selenium/tests/hars/issue-78/html.har
@@ -1,0 +1,116 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-06-25T07:18:57.500Z",
+        "id": "page_1",
+        "title": "HTML",
+        "pageTimings": {
+          "onContentLoad": 276.01199999980963,
+          "onLoad": 275.79100000002654
+        }
+      }
+    ],
+    "entries": [
+      {
+        "startedDateTime": "2016-06-25T07:18:57.500Z",
+        "time": 12.028000000100292,
+        "request": {
+          "method": "GET",
+          "url": "http://harviewer:8080/webapp/",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "Host",
+              "value": "harviewer:8080"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-GB,en-US;q=0.8,en;q=0.6"
+            },
+            {
+              "name": "Upgrade-Insecure-Requests",
+              "value": "1"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"
+            },
+            {
+              "name": "Accept",
+              "value": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "max-age=0"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 469,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Sat, 25 Jun 2016 07:18:57 GMT"
+            },
+            {
+              "name": "Server",
+              "value": "Apache-Coyote/1.1"
+            },
+            {
+              "name": "Content-Length",
+              "value": "456"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/html"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 456,
+            "mimeType": "text/html",
+            "compression": 0,
+            "text": "<!doctype html>\r\n<html>\r\n<head>\r\n    <title>HTTP Archive Viewer @VERSION@</title>\r\n    <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\">\r\n    <link rel=\"stylesheet\" href=\"css/harViewer.css\" type=\"text/css\">\r\n</head>\r\n<body class=\"harBody\">\r\n    <div id=\"content\" version=\"@VERSION@\"></div>\r\n    <script src=\"scripts/jquery.js\"></script>\r\n    <script data-main=\"scripts/harViewer\" src=\"scripts/require.js\"></script>\r\n    </body>\r\n</html>\r\n"
+          },
+          "redirectURL": "",
+          "headersSize": 129,
+          "bodySize": 456,
+          "_transferSize": 585
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 0.231999999869004,
+          "dns": 1.1509999999361762,
+          "connect": 0.8259999999609098,
+          "send": 0.18100000033883035,
+          "wait": 9.13799999989348,
+          "receive": 0.5000000001018918,
+          "ssl": -1
+        },
+        "serverIPAddress": "192.168.1.80",
+        "connection": "1369",
+        "pageref": "page_1"
+      }
+    ]
+  }
+}

--- a/selenium/tests/hars/issue-78/json.har
+++ b/selenium/tests/hars/issue-78/json.har
@@ -1,0 +1,156 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-06-25T07:18:57.500Z",
+        "id": "page_1",
+        "title": "JSON",
+        "pageTimings": {
+          "onContentLoad": 276.01199999980963,
+          "onLoad": 275.79100000002654
+        }
+      }
+    ],
+    "entries": [
+      {
+        "startedDateTime": "2016-06-25T07:18:57.500Z",
+        "time": 1059.816999999839,
+        "request": {
+          "method": "GET",
+          "url": "http://jsonplaceholder.typicode.com/posts/1",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "Host",
+              "value": "jsonplaceholder.typicode.com"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-GB,en-US;q=0.8,en;q=0.6"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"
+            },
+            {
+              "name": "Accept",
+              "value": "*/*"
+            },
+            {
+              "name": "Referer",
+              "value": "http://jsonplaceholder.typicode.com/"
+            },
+            {
+              "name": "X-Requested-With",
+              "value": "XMLHttpRequest"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 434,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "Date",
+              "value": "Thu, 23 Jun 2016 19:42:24 GMT"
+            },
+            {
+              "name": "Via",
+              "value": "1.1 vegur"
+            },
+            {
+              "name": "X-Content-Type-Options",
+              "value": "nosniff"
+            },
+            {
+              "name": "Server",
+              "value": "Cowboy"
+            },
+            {
+              "name": "X-Powered-By",
+              "value": "Express"
+            },
+            {
+              "name": "Vary",
+              "value": "Origin, Accept-Encoding"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "no-cache"
+            },
+            {
+              "name": "Access-Control-Allow-Credentials",
+              "value": "true"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Content-Length",
+              "value": "292"
+            },
+            {
+              "name": "Etag",
+              "value": "W/\"124-yv65LoT2uMHrpn06wNpAcQ\""
+            },
+            {
+              "name": "Expires",
+              "value": "-1"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 292,
+            "mimeType": "application/json",
+            "compression": 0,
+            "text": "{\n  \"userId\": 1,\n  \"id\": 1,\n  \"title\": \"sunt aut facere repellat provident occaecati excepturi optio reprehenderit\",\n  \"body\": \"quia et suscipit\\nsuscipit recusandae consequuntur expedita et cum\\nreprehenderit molestiae ut ut quas totam\\nnostrum rerum est autem sunt rem eveniet architecto\"\n}"
+          },
+          "redirectURL": "",
+          "headersSize": 401,
+          "bodySize": 292,
+          "_transferSize": 693
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 2.2039999998924,
+          "dns": 241.2650000001126,
+          "connect": 149.63699999998403,
+          "send": 0.2530000001569874,
+          "wait": 666.033999999854,
+          "receive": 0.4239999998389976,
+          "ssl": -1
+        },
+        "serverIPAddress": "107.21.111.236",
+        "connection": "19057",
+        "pageref": "page_1"
+      }
+    ]
+  }
+}

--- a/selenium/tests/hars/issue-78/xml.har
+++ b/selenium/tests/hars/issue-78/xml.har
@@ -1,0 +1,136 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-06-25T07:18:57.500Z",
+        "id": "page_1",
+        "title": "XML",
+        "pageTimings": {
+          "onContentLoad": 276.01199999980963,
+          "onLoad": 275.79100000002654
+        }
+      }
+    ],
+    "entries": [
+      {
+        "startedDateTime": "2016-06-25T07:18:57.500Z",
+        "time": 129.6519999998509,
+        "request": {
+          "method": "GET",
+          "url": "XML",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "Host",
+              "value": "www.w3schools.com"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-GB,en-US;q=0.8,en;q=0.6"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"
+            },
+            {
+              "name": "Accept",
+              "value": "*/*"
+            },
+            {
+              "name": "Referer",
+              "value": "http://www.w3schools.com/xml/tryit.asp?filename=try_dom_xmlhttprequest_xml"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 438,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Thu, 23 Jun 2016 19:08:40 GMT"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Tue, 06 Jan 2015 07:34:48 GMT"
+            },
+            {
+              "name": "Server",
+              "value": "ECS (mia/17DB)"
+            },
+            {
+              "name": "X-Powered-By",
+              "value": "ASP.NET"
+            },
+            {
+              "name": "Etag",
+              "value": "\"9ec94c408329d01:0\""
+            },
+            {
+              "name": "X-Cache",
+              "value": "HIT"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/xml"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "public,max-age=3600,public"
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "Content-Length",
+              "value": "4709"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 4709,
+            "mimeType": "text/xml",
+            "compression": 0,
+            "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<CATALOG>\r\n\t<CD>\r\n\t\t<TITLE>Empire Burlesque</TITLE>\r\n\t\t<ARTIST>Bob Dylan</ARTIST>\r\n\t\t<COUNTRY>USA</COUNTRY>\r\n\t\t<COMPANY>Columbia</COMPANY>\r\n\t\t<PRICE>10.90</PRICE>\r\n\t\t<YEAR>1985</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Hide your heart</TITLE>\r\n\t\t<ARTIST>Bonnie Tyler</ARTIST>\r\n\t\t<COUNTRY>UK</COUNTRY>\r\n\t\t<COMPANY>CBS Records</COMPANY>\r\n\t\t<PRICE>9.90</PRICE>\r\n\t\t<YEAR>1988</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Greatest Hits</TITLE>\r\n\t\t<ARTIST>Dolly Parton</ARTIST>\r\n\t\t<COUNTRY>USA</COUNTRY>\r\n\t\t<COMPANY>RCA</COMPANY>\r\n\t\t<PRICE>9.90</PRICE>\r\n\t\t<YEAR>1982</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Still got the blues</TITLE>\r\n\t\t<ARTIST>Gary Moore</ARTIST>\r\n\t\t<COUNTRY>UK</COUNTRY>\r\n\t\t<COMPANY>Virgin records</COMPANY>\r\n\t\t<PRICE>10.20</PRICE>\r\n\t\t<YEAR>1990</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Eros</TITLE>\r\n\t\t<ARTIST>Eros Ramazzotti</ARTIST>\r\n\t\t<COUNTRY>EU</COUNTRY>\r\n\t\t<COMPANY>BMG</COMPANY>\r\n\t\t<PRICE>9.90</PRICE>\r\n\t\t<YEAR>1997</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>One night only</TITLE>\r\n\t\t<ARTIST>Bee Gees</ARTIST>\r\n\t\t<COUNTRY>UK</COUNTRY>\r\n\t\t<COMPANY>Polydor</COMPANY>\r\n\t\t<PRICE>10.90</PRICE>\r\n\t\t<YEAR>1998</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Sylvias Mother</TITLE>\r\n\t\t<ARTIST>Dr.Hook</ARTIST>\r\n\t\t<COUNTRY>UK</COUNTRY>\r\n\t\t<COMPANY>CBS</COMPANY>\r\n\t\t<PRICE>8.10</PRICE>\r\n\t\t<YEAR>1973</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Maggie May</TITLE>\r\n\t\t<ARTIST>Rod Stewart</ARTIST>\r\n\t\t<COUNTRY>UK</COUNTRY>\r\n\t\t<COMPANY>Pickwick</COMPANY>\r\n\t\t<PRICE>8.50</PRICE>\r\n\t\t<YEAR>1990</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Romanza</TITLE>\r\n\t\t<ARTIST>Andrea Bocelli</ARTIST>\r\n\t\t<COUNTRY>EU</COUNTRY>\r\n\t\t<COMPANY>Polydor</COMPANY>\r\n\t\t<PRICE>10.80</PRICE>\r\n\t\t<YEAR>1996</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>When a man loves a woman</TITLE>\r\n\t\t<ARTIST>Percy Sledge</ARTIST>\r\n\t\t<COUNTRY>USA</COUNTRY>\r\n\t\t<COMPANY>Atlantic</COMPANY>\r\n\t\t<PRICE>8.70</PRICE>\r\n\t\t<YEAR>1987</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Black angel</TITLE>\r\n\t\t<ARTIST>Savage Rose</ARTIST>\r\n\t\t<COUNTRY>EU</COUNTRY>\r\n\t\t<COMPANY>Mega</COMPANY>\r\n\t\t<PRICE>10.90</PRICE>\r\n\t\t<YEAR>1995</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>1999 Grammy Nominees</TITLE>\r\n\t\t<ARTIST>Many</ARTIST>\r\n\t\t<COUNTRY>USA</COUNTRY>\r\n\t\t<COMPANY>Grammy</COMPANY>\r\n\t\t<PRICE>10.20</PRICE>\r\n\t\t<YEAR>1999</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>For the good times</TITLE>\r\n\t\t<ARTIST>Kenny Rogers</ARTIST>\r\n\t\t<COUNTRY>UK</COUNTRY>\r\n\t\t<COMPANY>Mucik Master</COMPANY>\r\n\t\t<PRICE>8.70</PRICE>\r\n\t\t<YEAR>1995</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Big Willie style</TITLE>\r\n\t\t<ARTIST>Will Smith</ARTIST>\r\n\t\t<COUNTRY>USA</COUNTRY>\r\n\t\t<COMPANY>Columbia</COMPANY>\r\n\t\t<PRICE>9.90</PRICE>\r\n\t\t<YEAR>1997</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Tupelo Honey</TITLE>\r\n\t\t<ARTIST>Van Morrison</ARTIST>\r\n\t\t<COUNTRY>UK</COUNTRY>\r\n\t\t<COMPANY>Polydor</COMPANY>\r\n\t\t<PRICE>8.20</PRICE>\r\n\t\t<YEAR>1971</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Soulsville</TITLE>\r\n\t\t<ARTIST>Jorn Hoel</ARTIST>\r\n\t\t<COUNTRY>Norway</COUNTRY>\r\n\t\t<COMPANY>WEA</COMPANY>\r\n\t\t<PRICE>7.90</PRICE>\r\n\t\t<YEAR>1996</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>The very best of</TITLE>\r\n\t\t<ARTIST>Cat Stevens</ARTIST>\r\n\t\t<COUNTRY>UK</COUNTRY>\r\n\t\t<COMPANY>Island</COMPANY>\r\n\t\t<PRICE>8.90</PRICE>\r\n\t\t<YEAR>1990</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Stop</TITLE>\r\n\t\t<ARTIST>Sam Brown</ARTIST>\r\n\t\t<COUNTRY>UK</COUNTRY>\r\n\t\t<COMPANY>A and M</COMPANY>\r\n\t\t<PRICE>8.90</PRICE>\r\n\t\t<YEAR>1988</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Bridge of Spies</TITLE>\r\n\t\t<ARTIST>T'Pau</ARTIST>\r\n\t\t<COUNTRY>UK</COUNTRY>\r\n\t\t<COMPANY>Siren</COMPANY>\r\n\t\t<PRICE>7.90</PRICE>\r\n\t\t<YEAR>1987</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Private Dancer</TITLE>\r\n\t\t<ARTIST>Tina Turner</ARTIST>\r\n\t\t<COUNTRY>UK</COUNTRY>\r\n\t\t<COMPANY>Capitol</COMPANY>\r\n\t\t<PRICE>8.90</PRICE>\r\n\t\t<YEAR>1983</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Midt om natten</TITLE>\r\n\t\t<ARTIST>Kim Larsen</ARTIST>\r\n\t\t<COUNTRY>EU</COUNTRY>\r\n\t\t<COMPANY>Medley</COMPANY>\r\n\t\t<PRICE>7.80</PRICE>\r\n\t\t<YEAR>1983</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Pavarotti Gala Concert</TITLE>\r\n\t\t<ARTIST>Luciano Pavarotti</ARTIST>\r\n\t\t<COUNTRY>UK</COUNTRY>\r\n\t\t<COMPANY>DECCA</COMPANY>\r\n\t\t<PRICE>9.90</PRICE>\r\n\t\t<YEAR>1991</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>The dock of the bay</TITLE>\r\n\t\t<ARTIST>Otis Redding</ARTIST>\r\n\t\t<COUNTRY>USA</COUNTRY>\r\n\t\t<COMPANY>Atlantic</COMPANY>\r\n\t\t<PRICE>7.90</PRICE>\r\n\t\t<YEAR>1987</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Picture book</TITLE>\r\n\t\t<ARTIST>Simply Red</ARTIST>\r\n\t\t<COUNTRY>EU</COUNTRY>\r\n\t\t<COMPANY>Elektra</COMPANY>\r\n\t\t<PRICE>7.20</PRICE>\r\n\t\t<YEAR>1985</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Red</TITLE>\r\n\t\t<ARTIST>The Communards</ARTIST>\r\n\t\t<COUNTRY>UK</COUNTRY>\r\n\t\t<COMPANY>London</COMPANY>\r\n\t\t<PRICE>7.80</PRICE>\r\n\t\t<YEAR>1987</YEAR>\r\n\t</CD>\r\n\t<CD>\r\n\t\t<TITLE>Unchain my heart</TITLE>\r\n\t\t<ARTIST>Joe Cocker</ARTIST>\r\n\t\t<COUNTRY>USA</COUNTRY>\r\n\t\t<COMPANY>EMI</COMPANY>\r\n\t\t<PRICE>8.20</PRICE>\r\n\t\t<YEAR>1987</YEAR>\r\n\t</CD>\r\n</CATALOG>\r\n"
+          },
+          "redirectURL": "",
+          "headersSize": 301,
+          "bodySize": 4709,
+          "_transferSize": 5010
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 2.16299999988223,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.3090000000156601,
+          "wait": 125.6410000000871,
+          "receive": 1.5389999998658936,
+          "ssl": -1
+        },
+        "serverIPAddress": "72.21.91.8",
+        "connection": "3951",
+        "pageref": "page_1"
+      }
+    ]
+  }
+}

--- a/tests/functional/testRequestBody.js
+++ b/tests/functional/testRequestBody.js
@@ -37,19 +37,33 @@ define([
       .end(2);
   }
 
-  function testTabBodyContainsText(remote, url, expectedPageTitle, tabName, expectedTabBody) {
-    var utils = new DriverUtils(remote);
-    return clickFirstNetLabel(remote, url, expectedPageTitle)
-      .findByCssSelector(".netInfoRow")
-      .findByCssSelector("." + tabName + "Tab.tab")
-      .click()
-      .then(utils.cbAssertElementContainsText("css=.tab" + tabName + "Body.tabBody.selected ", expectedTabBody));
+  function clickTab(tabName) {
+    return function() {
+      return this.parent
+        .findByCssSelector(".netInfoRow")
+        .findByCssSelector("." + tabName + "Tab.tab")
+        .click();
+    };
   }
 
   function getVisibleTextForAll(els) {
     return Promise.all(els.map(function(el, i) {
       return el.getVisibleText();
     }));
+  }
+
+  function testTabBodyContainsText(remote, url, expectedPageTitle, tabName, expectedTabBody) {
+    var utils = new DriverUtils(remote);
+    return clickFirstNetLabel(remote, url, expectedPageTitle)
+      .then(clickTab(tabName))
+      .then(utils.cbAssertElementContainsText("css=.tab" + tabName + "Body.tabBody.selected ", expectedTabBody));
+  }
+
+  function testSyntaxHighlighting(remote, url, expectedPageTitle) {
+      return clickFirstNetLabel(remote, url, expectedPageTitle)
+        .then(clickTab("Response"))
+        // We assume that finding the following class means syntax highlighter has worked.
+        .findByCssSelector(".dp-highlighter")
   }
 
   registerSuite({
@@ -105,6 +119,26 @@ define([
         .then(function(tabLabels) {
             assert.include(tabLabels, "Post", '"Post" tab should be present');
         });
+    },
+
+    'testIssue78 - HTML': function() {
+      var url = harViewerBase + "?path=" + testBase + "tests/hars/issue-78/html.har";
+      return testSyntaxHighlighting(this.remote, url, "HTML");
+    },
+
+    'testIssue78 - JSON': function() {
+      var url = harViewerBase + "?path=" + testBase + "tests/hars/issue-78/json.har";
+      return testSyntaxHighlighting(this.remote, url, "JSON");
+    },
+
+    'testIssue78 - XML': function() {
+      var url = harViewerBase + "?path=" + testBase + "tests/hars/issue-78/xml.har";
+      return testSyntaxHighlighting(this.remote, url, "XML");
+    },
+
+    'testIssue78 - CSS': function() {
+      var url = harViewerBase + "?path=" + testBase + "tests/hars/issue-78/css.har";
+      return testSyntaxHighlighting(this.remote, url, "CSS");
     }
   });
 });

--- a/webapp/scripts/core/lib.js
+++ b/webapp/scripts/core/lib.js
@@ -423,6 +423,18 @@ Lib.toISOString = function(date)
 },
 
 //*************************************************************************************************
+// Mime Types
+
+Lib.extractMimeType = function(mimeType) {
+    // remove parameters (if any)
+    var idx = mimeType.indexOf(";");
+    if (idx > -1) {
+        mimeType = mimeType.substring(0, idx).trim();
+    }
+    return mimeType;
+};
+
+//*************************************************************************************************
 // URL
 
 Lib.getFileName = function(url)

--- a/webapp/scripts/syntax-highlighter/shCore.js
+++ b/webapp/scripts/syntax-highlighter/shCore.js
@@ -740,6 +740,146 @@ dp.sh.Brushes.JScript = function()
 dp.sh.Brushes.JScript.prototype = new dp.sh.Highlighter();
 dp.sh.Brushes.JScript.Aliases   = ['js', 'jscript', 'javascript'];
 
+//*************************************************************************************************
+
+dp.sh.Brushes.Xml = function()
+{
+	this.CssClass = 'dp-xml';
+	this.Style =	'.dp-xml .cdata { color: #ff1493; }' +
+					'.dp-xml .tag, .dp-xml .tag-name { color: #069; font-weight: bold; }' +
+					'.dp-xml .attribute { color: red; }' +
+					'.dp-xml .attribute-value { color: blue; }';
+}
+
+dp.sh.Brushes.Xml.prototype	= new dp.sh.Highlighter();
+dp.sh.Brushes.Xml.Aliases	= ['xml', 'xhtml', 'xslt', 'html', 'xhtml'];
+
+dp.sh.Brushes.Xml.prototype.ProcessRegexList = function()
+{
+	function push(array, value)
+	{
+		array[array.length] = value;
+	}
+
+	/* If only there was a way to get index of a group within a match, the whole XML
+	   could be matched with the expression looking something like that:
+
+	   (<!\[CDATA\[\s*.*\s*\]\]>)
+	   | (<!--\s*.*\s*?-->)
+	   | (<)*(\w+)*\s*(\w+)\s*=\s*(".*?"|'.*?'|\w+)(/*>)*
+	   | (</?)(.*?)(/?>)
+	*/
+	var index	= 0;
+	var match	= null;
+	var regex	= null;
+
+	// Match CDATA in the following format <![ ... [ ... ]]>
+	// (\&lt;|<)\!\[[\w\s]*?\[(.|\s)*?\]\](\&gt;|>)
+	this.GetMatches(new RegExp('(\&lt;|<)\\!\\[[\\w\\s]*?\\[(.|\\s)*?\\]\\](\&gt;|>)', 'gm'), 'cdata');
+
+	// Match comments
+	// (\&lt;|<)!--\s*.*?\s*--(\&gt;|>)
+	this.GetMatches(new RegExp('(\&lt;|<)!--\\s*.*?\\s*--(\&gt;|>)', 'gm'), 'comments');
+
+	// Match attributes and their values
+	// (:|\w+)\s*=\s*(".*?"|\'.*?\'|\w+)*
+	regex = new RegExp('([:\\w-\.]+)\\s*=\\s*(".*?"|\'.*?\'|\\w+)*|(\\w+)', 'gm'); // Thanks to Tomi Blinnikka of Yahoo! for fixing namespaces in attributes
+	while((match = regex.exec(this.code)) != null)
+	{
+		if(match[1] == null)
+		{
+			continue;
+		}
+
+		push(this.matches, new dp.sh.Match(match[1], match.index, 'attribute'));
+
+		// if xml is invalid and attribute has no property value, ignore it
+		if(match[2] != undefined)
+		{
+			push(this.matches, new dp.sh.Match(match[2], match.index + match[0].indexOf(match[2]), 'attribute-value'));
+		}
+	}
+
+	// Match opening and closing tag brackets
+	// (\&lt;|<)/*\?*(?!\!)|/*\?*(\&gt;|>)
+	this.GetMatches(new RegExp('(\&lt;|<)/*\\?*(?!\\!)|/*\\?*(\&gt;|>)', 'gm'), 'tag');
+
+	// Match tag names
+	// (\&lt;|<)/*\?*\s*(\w+)
+	regex = new RegExp('(?:\&lt;|<)/*\\?*\\s*([:\\w-\.]+)', 'gm');
+	while((match = regex.exec(this.code)) != null)
+	{
+		push(this.matches, new dp.sh.Match(match[1], match.index + match[0].indexOf(match[1]), 'tag-name'));
+	}
+}
+
+//*************************************************************************************************
+
+dp.sh.Brushes.CSS = function()
+{
+	var keywords =	'ascent azimuth background-attachment background-color background-image background-position ' +
+					'background-repeat background baseline bbox border-collapse border-color border-spacing border-style border-top ' +
+					'border-right border-bottom border-left border-top-color border-right-color border-bottom-color border-left-color ' +
+					'border-top-style border-right-style border-bottom-style border-left-style border-top-width border-right-width ' +
+					'border-bottom-width border-left-width border-width border cap-height caption-side centerline clear clip color ' +
+					'content counter-increment counter-reset cue-after cue-before cue cursor definition-src descent direction display ' +
+					'elevation empty-cells float font-size-adjust font-family font-size font-stretch font-style font-variant font-weight font ' +
+					'height letter-spacing line-height list-style-image list-style-position list-style-type list-style margin-top ' +
+					'margin-right margin-bottom margin-left margin marker-offset marks mathline max-height max-width min-height min-width orphans ' +
+					'outline-color outline-style outline-width outline overflow padding-top padding-right padding-bottom padding-left padding page ' +
+					'page-break-after page-break-before page-break-inside pause pause-after pause-before pitch pitch-range play-during position ' +
+					'quotes richness size slope src speak-header speak-numeral speak-punctuation speak speech-rate stemh stemv stress ' +
+					'table-layout text-align text-decoration text-indent text-shadow text-transform unicode-bidi unicode-range units-per-em ' +
+					'vertical-align visibility voice-family volume white-space widows width widths word-spacing x-height z-index';
+
+	var values =	'above absolute all always aqua armenian attr aural auto avoid baseline behind below bidi-override black blink block blue bold bolder '+
+					'both bottom braille capitalize caption center center-left center-right circle close-quote code collapse compact condensed '+
+					'continuous counter counters crop cross crosshair cursive dashed decimal decimal-leading-zero default digits disc dotted double '+
+					'embed embossed e-resize expanded extra-condensed extra-expanded fantasy far-left far-right fast faster fixed format fuchsia '+
+					'gray green groove handheld hebrew help hidden hide high higher icon inline-table inline inset inside invert italic '+
+					'justify landscape large larger left-side left leftwards level lighter lime line-through list-item local loud lower-alpha '+
+					'lowercase lower-greek lower-latin lower-roman lower low ltr marker maroon medium message-box middle mix move narrower '+
+					'navy ne-resize no-close-quote none no-open-quote no-repeat normal nowrap n-resize nw-resize oblique olive once open-quote outset '+
+					'outside overline pointer portrait pre print projection purple red relative repeat repeat-x repeat-y rgb ridge right right-side '+
+					'rightwards rtl run-in screen scroll semi-condensed semi-expanded separate se-resize show silent silver slower slow '+
+					'small small-caps small-caption smaller soft solid speech spell-out square s-resize static status-bar sub super sw-resize '+
+					'table-caption table-cell table-column table-column-group table-footer-group table-header-group table-row table-row-group teal '+
+					'text-bottom text-top thick thin top transparent tty tv ultra-condensed ultra-expanded underline upper-alpha uppercase upper-latin '+
+					'upper-roman url visible wait white wider w-resize x-fast x-high x-large x-loud x-low x-slow x-small x-soft xx-large xx-small yellow';
+
+	var fonts =		'[mM]onospace [tT]ahoma [vV]erdana [aA]rial [hH]elvetica [sS]ans-serif [sS]erif';
+
+	this.regexList = [
+		{ regex: dp.sh.RegexLib.MultiLineCComments,						css: 'comment' },	// multiline comments
+		{ regex: dp.sh.RegexLib.DoubleQuotedString,						css: 'string' },	// double quoted strings
+		{ regex: dp.sh.RegexLib.SingleQuotedString,						css: 'string' },	// single quoted strings
+		{ regex: new RegExp('\\#[a-zA-Z0-9]{3,6}', 'g'),				css: 'value' },		// html colors
+		{ regex: new RegExp('(-?\\d+)(\.\\d+)?(px|em|pt|\:|\%|)', 'g'),	css: 'value' },		// sizes
+		{ regex: new RegExp('!important', 'g'),							css: 'important' },	// !important
+		{ regex: new RegExp(this.GetKeywordsCSS(keywords), 'gm'),		css: 'keyword' },	// keywords
+		{ regex: new RegExp(this.GetValuesCSS(values), 'g'),			css: 'value' },		// values
+		{ regex: new RegExp(this.GetValuesCSS(fonts), 'g'),				css: 'value' }		// fonts
+		];
+
+	this.CssClass = 'dp-css';
+	this.Style =	'.dp-css .value { color: black; }' +
+					'.dp-css .important { color: red; }'
+					;
+}
+
+dp.sh.Highlighter.prototype.GetKeywordsCSS = function(str)
+{
+	return '\\b([a-z_]|)' + str.replace(/ /g, '(?=:)\\b|\\b([a-z_\\*]|\\*|)') + '(?=:)\\b';
+}
+
+dp.sh.Highlighter.prototype.GetValuesCSS = function(str)
+{
+	return '\\b' + str.replace(/ /g, '(?!-)(?!:)\\b|\\b()') + '\:\\b';
+}
+
+dp.sh.Brushes.CSS.prototype	= new dp.sh.Highlighter();
+dp.sh.Brushes.CSS.Aliases	= ['css'];
+
 return dp;
 
 //*************************************************************************************************


### PR DESCRIPTION
Downloaded syntaxhighlighter from:

https://storage.googleapis.com/google-code-archive-source/v2/code.google.com/syntaxhighlighter/source-archive.zip

Used the 1.5.1 branch to extract the XML and CSS brushes to add to
shCore.js.

Added tests.

Fixes #78.