### PR TITLE
Handle missing response.content.mimeType

### DIFF
--- a/selenium/tests/hars/issue-56/missing-content-type.har
+++ b/selenium/tests/hars/issue-56/missing-content-type.har
@@ -1,0 +1,131 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "WebInspector",
+      "version": "537.36"
+    },
+    "pages": [
+      {
+        "startedDateTime": "2016-06-25T07:18:57.500Z",
+        "id": "page_1",
+        "title": "CSS",
+        "pageTimings": {
+          "onContentLoad": 276.01199999980963,
+          "onLoad": 275.79100000002654
+        }
+      }
+    ],
+    "entries": [
+      {
+        "startedDateTime": "2016-06-25T07:18:57.500Z",
+        "time": 25.965000000724103,
+        "request": {
+          "method": "GET",
+          "url": "http://harviewer:49001/webapp/css/dragdrop.css",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Pragma",
+              "value": "no-cache"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate, sdch"
+            },
+            {
+              "name": "Host",
+              "value": "harviewer:49001"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-GB,en-US;q=0.8,en;q=0.6"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"
+            },
+            {
+              "name": "Accept",
+              "value": "text/css,*/*;q=0.1"
+            },
+            {
+              "name": "Referer",
+              "value": "http://harviewer:49001/webapp/?path=/selenium/tests/hars/issue-78/css.har"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "no-cache"
+            }
+          ],
+          "queryString": [],
+          "cookies": [],
+          "headersSize": 530,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "OK",
+          "httpVersion": "HTTP/1.1",
+          "headers": [
+            {
+              "name": "Date",
+              "value": "Sat, 25 Jun 2016 10:16:07 GMT"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Tue, 02 Jun 2015 06:52:17 GMT"
+            },
+            {
+              "name": "Server",
+              "value": "Apache-Coyote/1.1"
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "ETag",
+              "value": "W/\"176-1433227937851\""
+            },
+            {
+              "name": "Content-Length",
+              "value": "176"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/css"
+            }
+          ],
+          "cookies": [],
+          "content": {
+            "size": 176,
+            "compression": 0,
+            "text": "/* See license.txt for terms of usage */\r\n\r\nbody[vResizing=\"true\"] * {\r\n    cursor: e-resize !important;\r\n}\r\n\r\nbody[hResizing=\"true\"] * {\r\n    cursor: s-resize !important;\r\n}\r\n"
+          },
+          "redirectURL": "",
+          "headersSize": 225,
+          "bodySize": 176,
+          "_transferSize": 401
+        },
+        "cache": {},
+        "timings": {
+          "blocked": 21.759999999631,
+          "dns": -1,
+          "connect": -1,
+          "send": 0.20600000061670087,
+          "wait": 1.3010000002396005,
+          "receive": 2.698000000236803,
+          "ssl": -1
+        },
+        "serverIPAddress": "192.168.1.80",
+        "connection": "12431",
+        "pageref": "page_1"
+      }
+    ]
+  }
+}

--- a/tests/functional/appDriver.js
+++ b/tests/functional/appDriver.js
@@ -101,11 +101,30 @@ define([
     };
   }
 
+  function disableValidation() {
+    return function() {
+      var parent = this.parent;
+      return parent
+        .findByCssSelector("#validate")
+        .then(function(el) {
+          // If the checkbox's "checked" property is true, then click to uncheck.
+          // Why click() and not set the property directly? Because the cookie
+          // in HAR Viewer is only set when a click event occurs.
+          // Alternatively, we could set the cookie directly.
+          return el.getProperty("checked")
+            .then(function(checked) {
+              return checked ? el.click() : 1;
+            });
+        });
+    };
+  }
+
   return {
     openAndClickNetLabel: openAndClickNetLabel,
     openAndClickFirstNetLabel: openAndClickFirstNetLabel,
     clickTab: clickTab,
     waitForImageToLoad: waitForImageToLoad,
-    getVisibleTextForAll: getVisibleTextForAll
+    getVisibleTextForAll: getVisibleTextForAll,
+    disableValidation: disableValidation
   };
 });

--- a/tests/functional/testRequestBody.js
+++ b/tests/functional/testRequestBody.js
@@ -190,6 +190,33 @@ define([
       var delta = 1;
       // Chrome and FF report the SVG width/height as 515.  IE reports as 514, so need a delta.
       return testImageDimensions(this.remote, url, "issue-23", 1, false, 515, 515, delta);
+    },
+
+    'testIssue56': {
+      'testIssue56 - Handle missing response.content.mimetype gracefully': function() {
+        var r = this.remote;
+
+        var url = harViewerBase + "?path=" + testBase + "tests/hars/issue-56/missing-content-type.har";
+        var expectedPageTitle = "CSS";
+        var expectedTabBody = "See license.txt for terms of usage";
+
+        // The HAR is invalid, so browse to base page first, turn off
+        // validation and only then do the main test.
+        // We're testing that HAR Viewer handles the lack of
+        // response.content.mimeType gracefully.
+        return r
+          .setFindTimeout(findTimeout)
+          .get(harViewerBase)
+          .then(appDriver.disableValidation())
+          .then(function() {
+            return testTabBodyContainsText(r, url, expectedPageTitle, "Response", expectedTabBody);
+          });
+      },
+
+      teardown: function() {
+        // Clear cookies to return to clean state for other tests
+        return this.remote.clearCookies();
+      }
     }
   });
 });

--- a/tests/functional/testValidateCheckbox.js
+++ b/tests/functional/testValidateCheckbox.js
@@ -48,6 +48,11 @@ define([
           assert.strictEqual(cookie.name, "validate");
           assert.strictEqual(cookie.value, "true");
         })
+    },
+
+    teardown: function() {
+      // Clear cookies to return to clean state for other tests
+      return this.remote.clearCookies();
     }
   });
 });

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -45,6 +45,7 @@ define([
   config.suites = config.suites.concat([
     'tests/unit/core/lib',
     'tests/unit/core/cookies',
+    'tests/unit/core/mime',
     'tests/unit/core/StatsService'
   ]);
 

--- a/tests/unit/core/mime.js
+++ b/tests/unit/core/mime.js
@@ -1,0 +1,45 @@
+/**
+ * Test core/mime.
+ */
+define([
+    "intern!object",
+    "intern/chai!assert",
+    "core/mime"
+], function (registerSuite, assert, Mime) {
+
+    var extractMimeTypeData = [
+        ['of null returns ""', null, Error],
+        ['of undefined returns ""', null, Error],
+        ['of 0 returns ""', 0, Error],
+        ['of 1 returns ""', 1, Error],
+        ['of true returns ""', true, Error],
+        ['of false returns ""', false, Error],
+        ['of "" returns ""', "", ""],
+        ['of "text/html" returns "text/html"', "text/html", "text/html"],
+        ['of "text/html;charset=UTF-8" returns "text/html"', "text/html;charset=UTF-8", "text/html"],
+        ['of "text/html; charset=UTF-8" returns "text/html"', "text/html; charset=UTF-8", "text/html"]
+    ];
+
+    var tests = extractMimeTypeData.reduce(function(tests, data) {
+        var testName = data[0];
+        var mimeType = data[1];
+        var expected = data[2];
+        var test = function() {
+            var actual = Mime.extractMimeType(mimeType);
+            assert.strictEqual(actual, expected);
+        };
+        tests[testName] = test;
+        if (expected === Error) {
+            // we expect an error, so wrap the test
+            tests[testName] = function() {
+                assert.throws(test);
+            }
+        }
+        return tests;
+    }, {});
+
+    registerSuite({
+        name: "core/mime",
+        'extractMimeType': tests
+    });
+});

--- a/webapp/scripts/core/mime.js
+++ b/webapp/scripts/core/mime.js
@@ -24,6 +24,9 @@ var Mime = {};
  * @return {String}
  */
 Mime.extractMimeType = function(mimeType) {
+    if ("string" !== typeof mimeType) {
+        throw new Error((typeof mimeType) + " is not of type string");
+    }
     // remove parameters (if any)
     var idx = mimeType.indexOf(";");
     if (idx > -1) {

--- a/webapp/scripts/preview/requestBody.js
+++ b/webapp/scripts/preview/requestBody.js
@@ -322,7 +322,7 @@ ImageTab.isFileImage = function(file) {
         return false;
     }
 
-    var mimeType = Lib.extractMimeType(content.mimeType);
+    var mimeType = Lib.extractMimeType(content.mimeType || "");
     return Lib.startsWith(mimeType, "image/");
 };
 
@@ -424,9 +424,8 @@ HighlightedTab.prototype = domplate(TabView.Tab.prototype,
 
         var content = this.file.response.content;
         var text = content.text;
-        var mimeType = content.mimeType || "";
         // Remove any mime type parameters (if any)
-        mimeType = Lib.extractMimeType(mimeType);
+        var mimeType = Lib.extractMimeType(content.mimeType);
 
         // Highlight the syntax if the mimeType is supported.
         var brush = HighlightedTab.shouldHighlightAs(mimeType);
@@ -461,9 +460,8 @@ HighlightedTab.canShowFile = function(file) {
         return false;
     }
 
-    var mimeType = content.mimeType || "";
     // Remove any mime type parameters (if any)
-    mimeType = Lib.extractMimeType(mimeType);
+    var mimeType = Lib.extractMimeType(content.mimeType || "");
 
     return (null !== HighlightedTab.shouldHighlightAs(mimeType));
 };
@@ -765,7 +763,7 @@ JsonTab.canShowFile = function(file) {
         return false;
     }
 
-    var mimeType = Lib.extractMimeType(content.mimeType);
+    var mimeType = Lib.extractMimeType(content.mimeType || "");
     return ["application/json"].indexOf(mimeType) > -1;
 };
 
@@ -799,7 +797,7 @@ XmlTab.prototype = domplate(TabView.Tab.prototype, {
 });
 
 XmlTab.isXmlMimeType = function(mimeType) {
-    var mimeType = Lib.extractMimeType(mimeType);
+    mimeType = Lib.extractMimeType(mimeType);
     return [
         "text/xml",
         "application/xml",
@@ -822,7 +820,8 @@ XmlTab.canShowFile = function(file) {
         return false;
     }
 
-    return XmlTab.isXmlMimeType(Lib.extractMimeType(content.mimeType));
+    var mimeType = Lib.extractMimeType(content.mimeType || "");
+    return XmlTab.isXmlMimeType(mimeType);
 };
 
 //*************************************************************************************************


### PR DESCRIPTION
Some HAR sources, such as BrowserMob Proxy, are not able to supply
`response.content.mimeType` in all responses (even though this field is
mandatory in the HAR 1.2 spec).

https://github.com/lightbody/browsermob-proxy/commit/d250e2a47b6f6660bc1903e73e44e973360e542e

As such, guard against a missing value when dealing with
`response.content.mimeType`.

Add unit tests for "core/mime.js" and response body test for missing mime
type.

Fixes #56