### PR TITLE
Add doneCallback for harModelLoader.loadArchives()

### DIFF
--- a/selenium/tests/testLoadArchives.html.php
+++ b/selenium/tests/testLoadArchives.html.php
@@ -1,0 +1,32 @@
+<?php
+require_once("config.php");
+?>
+
+<!doctype html>
+<html>
+<head>
+    <title>HAR Viewer Test Case</title>
+    <base href="<?php echo $harviewer_base ?>" />
+    <link rel="stylesheet" href="css/harViewer.css" type="text/css">
+</head>
+<body class="harBody">
+    <div id="content" version="test"></div>
+    <script src="scripts/jquery.js"></script>
+    <script data-main="scripts/harViewer" src="scripts/require.js"></script>
+    <script>
+    $("#content").bind("onViewerInit", function(event)
+    {
+        // Get application object
+        var viewer = event.target.repObject;
+        var hars = ["<?php echo $test_base.'tests/hars/testLoad3.har' ?>", "<?php echo $test_base.'tests/hars/simple.har' ?>"];
+        var harps = ["<?php echo $test_base.'tests/hars/testLoad1.harp' ?>"];
+
+        var callback = function() {};
+        var errorCallback = function() {};
+        var doneCallback = function() {};
+
+        viewer.loadArchives(hars, harps, 'callback_testLoad1', callback, errorCallback, doneCallback);
+    });
+    </script>
+</body>
+</html>

--- a/tests/functional/testLoadHarAPI.js
+++ b/tests/functional/testLoadHarAPI.js
@@ -13,6 +13,24 @@ define([
   var harViewerBase = intern.config.harviewer.harViewerBase;
   var testBase = intern.config.harviewer.testBase;
 
+  function testViewerLoadsThreeHars(remote, page) {
+    // Some of these tests need a larger timeout for finding DOM elements
+    // because we need the HAR to parse/display fully before we query the DOM.
+    var findTimeout = intern.config.harviewer.findTimeout;
+    var utils = new DriverUtils(remote);
+
+    var url = testBase + page;
+
+    return remote
+      .setFindTimeout(findTimeout)
+      // Open customized viewer.
+      .get(url)
+      // Wait for 10 sec to load HAR files.
+      .then(pollUntil("return (document.querySelectorAll('.pageTable').length == 3) || null", findTimeout))
+      .then(utils.cbAssertElementContainsText("css=.PreviewTab.selected", "Preview"))
+      .then(utils.cbAssertElementsLength(".pageTable", 3));
+  }
+
   registerSuite({
     name: 'testLoadHarAPI',
 
@@ -34,40 +52,31 @@ define([
     // currently uses hard-coded callback names.
 
     'testViewer': function() {
+      // This test loads a page that will use the harViewer.loadHar() API.
+      return testViewerLoadsThreeHars(this.remote, "tests/testLoadHarAPIViewer.html.php");
+    },
+
+    'testViewer loadArchives': function() {
+      // This test loads a page that will use the harViewer.loadArchives() API.
+      return testViewerLoadsThreeHars(this.remote, "tests/testLoadArchives.html.php");
+    },
+
+    'testPreview': function() {
       // Some of these tests need a larger timeout for finding DOM elements
       // because we need the HAR to parse/display fully before we query the DOM.
       var findTimeout = intern.config.harviewer.findTimeout;
       var r = this.remote;
       var utils = new DriverUtils(r);
 
-      var url = testBase + "tests/testLoadHarAPIViewer.html.php";
+      var url = testBase + "tests/testLoadHarAPIPreview.html.php";
 
       return r
         .setFindTimeout(findTimeout)
-        // Open customized viewer.
+        // Open customized preview.
         .get(url)
         // Wait for 10 sec to load HAR files.
         .then(pollUntil("return (document.querySelectorAll('.pageTable').length == 3) || null", findTimeout))
-        .then(utils.cbAssertElementContainsText("css=.PreviewTab.selected", "Preview"))
         .then(utils.cbAssertElementsLength(".pageTable", 3));
-      },
-
-      'testPreview': function() {
-        // Some of these tests need a larger timeout for finding DOM elements
-        // because we need the HAR to parse/display fully before we query the DOM.
-        var findTimeout = intern.config.harviewer.findTimeout;
-        var r = this.remote;
-        var utils = new DriverUtils(r);
-
-        var url = testBase + "tests/testLoadHarAPIPreview.html.php";
-
-        return r
-          .setFindTimeout(findTimeout)
-          // Open customized preview.
-          .get(url)
-          // Wait for 10 sec to load HAR files.
-          .then(pollUntil("return (document.querySelectorAll('.pageTable').length == 3) || null", findTimeout))
-          .then(utils.cbAssertElementsLength(".pageTable", 3));
-        }
+      }
   });
 });

--- a/tests/unit/preview/harModelLoader.js
+++ b/tests/unit/preview/harModelLoader.js
@@ -63,166 +63,256 @@ define([
         };
     }
 
-    registerSuite({
-        name: "preview/harModelLoader",
+    var getLoadOptionsSubSuite = {
+        'returns empty options when no parameters exist': function() {
+            var expected = makeExpected();
+            assert.deepEqual(Loader.getLoadOptions(""), expected);
+        },
 
-        'getLoadOptions': {
-            'returns empty options when no parameters exist': function() {
-                var expected = makeExpected();
-                assert.deepEqual(Loader.getLoadOptions(""), expected);
-            },
+        // Tests for legacy parameters, "path" and "inputUrl"
 
-            // Tests for legacy parameters, "path" and "inputUrl"
+        'single "path" parameter (with "baseUrl") populates "loadOptions.urls"': function() {
+            var baseUrl = "http://harviewer:49001/selenium/tests/hars/";
+            var paths = ["path.har"];
+            var expected = assign(makeExpected(), {
+                baseUrl: baseUrl,
+                urls: prefix(baseUrl, paths),
+                filePath: paths[0]
+            });
+            var actual = Loader.getLoadOptions(makeUrl(baseUrl, paths));
+            assert.deepEqual(actual, expected);
+        },
 
-            'single "path" parameter (with "baseUrl") populates "loadOptions.urls"': function() {
-                var baseUrl = "http://harviewer:49001/selenium/tests/hars/";
-                var paths = ["path.har"];
-                var expected = assign(makeExpected(), {
-                    baseUrl: baseUrl,
-                    urls: prefix(baseUrl, paths),
-                    filePath: paths[0]
+        'single "path" parameter (without "baseUrl") populates "loadOptions.urls"': function() {
+            var baseUrl = null;
+            var paths = ["path.har"];
+            var expected = assign(makeExpected(), {
+                baseUrl: baseUrl,
+                urls: prefix(baseUrl, paths),
+                filePath: paths[0]
+            });
+            var actual = Loader.getLoadOptions(makeUrl(baseUrl, paths));
+            assert.deepEqual(actual, expected);
+        },
+
+        'multiple "path" parameters (with "baseUrl") populates "loadOptions.urls"': function() {
+            var baseUrl = "http://harviewer:49001/selenium/tests/hars/";
+            var paths = ["path1.har", "path2.har"];
+            var expected = assign(makeExpected(), {
+                baseUrl: baseUrl,
+                urls: prefix(baseUrl, paths),
+                filePath: paths[0]
+            });
+            var actual = Loader.getLoadOptions(makeUrl(baseUrl, paths));
+            assert.deepEqual(actual, expected);
+        },
+
+        'multiple "path" parameters (without "baseUrl") populates "loadOptions.urls"': function() {
+            var baseUrl = null;
+            var paths = ["path1.har", "path2.har"];
+            var expected = assign(makeExpected(), {
+                baseUrl: baseUrl,
+                urls: prefix(baseUrl, paths),
+                filePath: paths[0]
+            });
+            var actual = Loader.getLoadOptions(makeUrl(baseUrl, paths));
+            assert.deepEqual(actual, expected);
+        },
+
+        'single "inputUrl" parameters (with "baseUrl") populates "loadOptions.urls" and "loadOptions.inputUrls"': function() {
+            var baseUrl = "http://harviewer:49001/selenium/tests/hars/";
+            var inputUrls = ["inputUrl.harp"];
+            var expected = assign(makeExpected(), {
+                baseUrl: baseUrl,
+                urls: inputUrls,
+                inputUrls: inputUrls
+            });
+            var actual = Loader.getLoadOptions(makeUrl(baseUrl, [], inputUrls));
+            assert.deepEqual(actual, expected);
+        },
+
+        'single "inputUrl" parameters (without "baseUrl") populates "loadOptions.urls" and "loadOptions.inputUrls"': function() {
+            var baseUrl = null;
+            var inputUrls = ["inputUrl.harp"];
+            var expected = assign(makeExpected(), {
+                baseUrl: baseUrl,
+                urls: inputUrls,
+                inputUrls: inputUrls
+            });
+            var actual = Loader.getLoadOptions(makeUrl(baseUrl, [], inputUrls));
+            assert.deepEqual(actual, expected);
+        },
+
+        'multiple "inputUrl" parameters (with "baseUrl") populates "loadOptions.urls" and "loadOptions.inputUrls"': function() {
+            var baseUrl = "http://harviewer:49001/selenium/tests/hars/";
+            var inputUrls = ["inputUrl1.harp", "inputUrl2.harp"];
+            var expected = assign(makeExpected(), {
+                baseUrl: baseUrl,
+                urls: inputUrls,
+                inputUrls: inputUrls
+            });
+            var actual = Loader.getLoadOptions(makeUrl(baseUrl, [], inputUrls));
+            assert.deepEqual(actual, expected);
+        },
+
+        'multiple "inputUrl" parameters (without "baseUrl") populates "loadOptions.urls" and "loadOptions.inputUrls"': function() {
+            var baseUrl = null;
+            var inputUrls = ["inputUrl1.harp", "inputUrl2.harp"];
+            var expected = assign(makeExpected(), {
+                baseUrl: baseUrl,
+                urls: inputUrls,
+                inputUrls: inputUrls
+            });
+            var actual = Loader.getLoadOptions(makeUrl(baseUrl, [], inputUrls));
+            assert.deepEqual(actual, expected);
+        },
+
+        'mixed "path" and "inputUrl" parameters (with "baseUrl") populates "loadOptions.urls" and "loadOptions.inputUrls"': function() {
+            var baseUrl = "http://harviewer:49001/selenium/tests/hars/";
+            var paths = ["path1.har", "path2.har"];
+            var inputUrls = ["inputUrl1.harp", "inputUrl2.harp"];
+            var expected = assign(makeExpected(), {
+                baseUrl: baseUrl,
+                urls: prefix(baseUrl, paths).concat(inputUrls),
+                inputUrls: inputUrls,
+                filePath: paths[0]
+            });
+            var actual = Loader.getLoadOptions(makeUrl(baseUrl, paths, inputUrls));
+            assert.deepEqual(actual, expected);
+        },
+
+        'mixed "path" and "inputUrl" parameters (without "baseUrl") populates "loadOptions.urls" and "loadOptions.inputUrls"': function() {
+            var baseUrl = null;
+            var paths = ["path1.har", "path2.har"];
+            var inputUrls = ["inputUrl1.harp", "inputUrl2.harp"];
+            var expected = assign(makeExpected(), {
+                baseUrl: baseUrl,
+                urls: prefix(baseUrl, paths).concat(inputUrls),
+                inputUrls: inputUrls,
+                filePath: paths[0]
+            });
+            var actual = Loader.getLoadOptions(makeUrl(baseUrl, paths, inputUrls));
+            assert.deepEqual(actual, expected);
+        },
+
+        // Tests for new parameters, "har" and "harp"
+
+        'single "har" parameter (without "baseUrl") populates "loadOptions.hars"': function() {
+            var baseUrl = null;
+            var hars = ["har.har"];
+            var expected = assign(makeExpected(), {
+                baseUrl: baseUrl,
+                hars: prefix(baseUrl, hars)
+            });
+            var actual = Loader.getLoadOptions(makeUrl(baseUrl, [], [], hars));
+            assert.deepEqual(actual, expected);
+        },
+
+        'single "har" parameter and single "path" parameter (without "baseUrl") populates "loadOptions.hars"': function() {
+            // Expect path to be ignored.
+            var baseUrl = null;
+            var hars = ["har.har"];
+            var paths = ["path.har"];
+            var expected = assign(makeExpected(), {
+                baseUrl: baseUrl,
+                hars: prefix(baseUrl, hars)
+            });
+            var actual = Loader.getLoadOptions(makeUrl(baseUrl, [], [], hars));
+            assert.deepEqual(actual, expected);
+        }
+    };
+
+    var loadArchivesSubSuite = (function() {
+        function counter() {
+            var f = function() {
+                f.count++;
+            };
+            f.count = 0;
+            return f;
+        }
+
+        var LoaderAjax = Loader.ajax;
+
+        var ajax = function(ajaxOpts) {
+            var context = ajaxOpts.context;
+            setTimeout(function() {
+                if (ajaxOpts.url === "error") {
+                    ajaxOpts.error.call(context);
+                } else {
+                    ajaxOpts.success.call(context);
+                }
+            }, 1);
+        };
+
+        function rejecter(value) {
+            return function(dfd) {
+                return dfd.callback(function() {
+                    throw new Error(value);
                 });
-                var actual = Loader.getLoadOptions(makeUrl(baseUrl, paths));
-                assert.deepEqual(actual, expected);
-            },
-
-            'single "path" parameter (without "baseUrl") populates "loadOptions.urls"': function() {
-                var baseUrl = null;
-                var paths = ["path.har"];
-                var expected = assign(makeExpected(), {
-                    baseUrl: baseUrl,
-                    urls: prefix(baseUrl, paths),
-                    filePath: paths[0]
-                });
-                var actual = Loader.getLoadOptions(makeUrl(baseUrl, paths));
-                assert.deepEqual(actual, expected);
-            },
-
-            'multiple "path" parameters (with "baseUrl") populates "loadOptions.urls"': function() {
-                var baseUrl = "http://harviewer:49001/selenium/tests/hars/";
-                var paths = ["path1.har", "path2.har"];
-                var expected = assign(makeExpected(), {
-                    baseUrl: baseUrl,
-                    urls: prefix(baseUrl, paths),
-                    filePath: paths[0]
-                });
-                var actual = Loader.getLoadOptions(makeUrl(baseUrl, paths));
-                assert.deepEqual(actual, expected);
-            },
-
-            'multiple "path" parameters (without "baseUrl") populates "loadOptions.urls"': function() {
-                var baseUrl = null;
-                var paths = ["path1.har", "path2.har"];
-                var expected = assign(makeExpected(), {
-                    baseUrl: baseUrl,
-                    urls: prefix(baseUrl, paths),
-                    filePath: paths[0]
-                });
-                var actual = Loader.getLoadOptions(makeUrl(baseUrl, paths));
-                assert.deepEqual(actual, expected);
-            },
-
-            'single "inputUrl" parameters (with "baseUrl") populates "loadOptions.urls" and "loadOptions.inputUrls"': function() {
-                var baseUrl = "http://harviewer:49001/selenium/tests/hars/";
-                var inputUrls = ["inputUrl.harp"];
-                var expected = assign(makeExpected(), {
-                    baseUrl: baseUrl,
-                    urls: inputUrls,
-                    inputUrls: inputUrls
-                });
-                var actual = Loader.getLoadOptions(makeUrl(baseUrl, [], inputUrls));
-                assert.deepEqual(actual, expected);
-            },
-
-            'single "inputUrl" parameters (without "baseUrl") populates "loadOptions.urls" and "loadOptions.inputUrls"': function() {
-                var baseUrl = null;
-                var inputUrls = ["inputUrl.harp"];
-                var expected = assign(makeExpected(), {
-                    baseUrl: baseUrl,
-                    urls: inputUrls,
-                    inputUrls: inputUrls
-                });
-                var actual = Loader.getLoadOptions(makeUrl(baseUrl, [], inputUrls));
-                assert.deepEqual(actual, expected);
-            },
-
-            'multiple "inputUrl" parameters (with "baseUrl") populates "loadOptions.urls" and "loadOptions.inputUrls"': function() {
-                var baseUrl = "http://harviewer:49001/selenium/tests/hars/";
-                var inputUrls = ["inputUrl1.harp", "inputUrl2.harp"];
-                var expected = assign(makeExpected(), {
-                    baseUrl: baseUrl,
-                    urls: inputUrls,
-                    inputUrls: inputUrls
-                });
-                var actual = Loader.getLoadOptions(makeUrl(baseUrl, [], inputUrls));
-                assert.deepEqual(actual, expected);
-            },
-
-            'multiple "inputUrl" parameters (without "baseUrl") populates "loadOptions.urls" and "loadOptions.inputUrls"': function() {
-                var baseUrl = null;
-                var inputUrls = ["inputUrl1.harp", "inputUrl2.harp"];
-                var expected = assign(makeExpected(), {
-                    baseUrl: baseUrl,
-                    urls: inputUrls,
-                    inputUrls: inputUrls
-                });
-                var actual = Loader.getLoadOptions(makeUrl(baseUrl, [], inputUrls));
-                assert.deepEqual(actual, expected);
-            },
-
-            'mixed "path" and "inputUrl" parameters (with "baseUrl") populates "loadOptions.urls" and "loadOptions.inputUrls"': function() {
-                var baseUrl = "http://harviewer:49001/selenium/tests/hars/";
-                var paths = ["path1.har", "path2.har"];
-                var inputUrls = ["inputUrl1.harp", "inputUrl2.harp"];
-                var expected = assign(makeExpected(), {
-                    baseUrl: baseUrl,
-                    urls: prefix(baseUrl, paths).concat(inputUrls),
-                    inputUrls: inputUrls,
-                    filePath: paths[0]
-                });
-                var actual = Loader.getLoadOptions(makeUrl(baseUrl, paths, inputUrls));
-                assert.deepEqual(actual, expected);
-            },
-
-            'mixed "path" and "inputUrl" parameters (without "baseUrl") populates "loadOptions.urls" and "loadOptions.inputUrls"': function() {
-                var baseUrl = null;
-                var paths = ["path1.har", "path2.har"];
-                var inputUrls = ["inputUrl1.harp", "inputUrl2.harp"];
-                var expected = assign(makeExpected(), {
-                    baseUrl: baseUrl,
-                    urls: prefix(baseUrl, paths).concat(inputUrls),
-                    inputUrls: inputUrls,
-                    filePath: paths[0]
-                });
-                var actual = Loader.getLoadOptions(makeUrl(baseUrl, paths, inputUrls));
-                assert.deepEqual(actual, expected);
-            },
-
-            // Tests for new parameters, "har" and "harp"
-
-            'single "har" parameter (without "baseUrl") populates "loadOptions.hars"': function() {
-                var baseUrl = null;
-                var hars = ["har.har"];
-                var expected = assign(makeExpected(), {
-                    baseUrl: baseUrl,
-                    hars: prefix(baseUrl, hars)
-                });
-                var actual = Loader.getLoadOptions(makeUrl(baseUrl, [], [], hars));
-                assert.deepEqual(actual, expected);
-            },
-
-            'single "har" parameter and single "path" parameter (without "baseUrl") populates "loadOptions.hars"': function() {
-                // Expect path to be ignored.
-                var baseUrl = null;
-                var hars = ["har.har"];
-                var paths = ["path.har"];
-                var expected = assign(makeExpected(), {
-                    baseUrl: baseUrl,
-                    hars: prefix(baseUrl, hars)
-                });
-                var actual = Loader.getLoadOptions(makeUrl(baseUrl, [], [], hars));
-                assert.deepEqual(actual, expected);
             }
         }
-    });
+
+        var callbackRejecter = rejecter("callback should not be called");
+        var errorCallbackRejecter = rejecter("errorCallback should not be called");
+        var doneCallbackRejecter = rejecter("doneCallback should not be called");
+        var noop = function() {};
+        var timeout = 500;
+
+        return {
+            beforeEach: function() {
+                Loader.ajax = ajax;
+            },
+
+            afterEach: function() {
+                Loader.ajax = LoaderAjax;
+            },
+
+            'null hars, null harps': function() {
+                var dfd = this.async(timeout);
+                Loader.loadArchives(null, null, null, callbackRejecter(dfd), errorCallbackRejecter(dfd), dfd.callback(noop));
+            },
+
+            'empty hars, empty harps': function() {
+                var dfd = this.async(timeout);
+                Loader.loadArchives([], [], null, callbackRejecter(dfd), errorCallbackRejecter(dfd), dfd.callback(noop));
+            },
+
+            '1 har error, empty harps': function() {
+                var dfd = this.async(timeout);
+                Loader.loadArchives(["error"], [], null, callbackRejecter(dfd), dfd.callback(noop), doneCallbackRejecter(dfd));
+            },
+
+            '1 ok har, 1 error har, empty harps': function() {
+                var dfd = this.async(timeout);
+                var callback = counter();
+                Loader.loadArchives(["1", "error"], [], null, callback, dfd.callback(function() {
+                    assert.strictEqual(callback.count, 1, "expect callback to be called once");
+                }), doneCallbackRejecter(dfd));
+            },
+
+            '1 har, null harps': function() {
+                var dfd = this.async(timeout);
+                var callback = counter();
+                Loader.loadArchives(["1"], [], null, callback, errorCallbackRejecter(dfd), dfd.callback(function() {
+                    assert.strictEqual(callback.count, 1, "expect callback to be called once");
+                }));
+            },
+
+            '1 har, 1 harp': function() {
+                var dfd = this.async(timeout);
+                var callback = counter();
+                Loader.loadArchives(["1"], ["1"], null, callback, errorCallbackRejecter(dfd), dfd.callback(function() {
+                    assert.strictEqual(callback.count, 2, "expect callback to be called twice");
+                }));
+            }
+        };
+    }());
+
+    var suite = {
+        name: "preview/harModelLoader",
+        'getLoadOptions': getLoadOptionsSubSuite,
+        'loadArchives': loadArchivesSubSuite
+    };
+
+    registerSuite(suite);
 });

--- a/webapp/scripts/harPreview.js
+++ b/webapp/scripts/harPreview.js
@@ -75,7 +75,7 @@ HarPreview.prototype =
     // Loading HAR files
 
     /**
-     * Load HAR file. See {@link HarView.loadHar} for documentation.
+     * Load HAR file. See {@link HarViewer.loadHar} for documentation.
      */
     loadHar: function(url, settings)
     {
@@ -85,6 +85,19 @@ HarPreview.prototype =
             settings.jsonpCallback,
             settings.success,
             settings.ajaxError);
+    },
+
+    /**
+     * Load HAR and HARP file. See {@link HarViewer.loadArchives} for documentation.
+     */
+    loadArchives: function(hars, harps, callbackName, callback, errorCallback, doneCallback) {
+        var self = this;
+        return Loader.loadArchives(hars, harps, callbackName, function(jsonString) {
+            self.appendPreview(jsonString);
+            if (callback) {
+                callback.apply(this, arguments);
+            }
+        }, errorCallback, doneCallback);
     },
 
     setPreviewColumns: function(cols, avoidCookies)

--- a/webapp/scripts/harViewer.js
+++ b/webapp/scripts/harViewer.js
@@ -181,6 +181,19 @@ HarView.prototype = Lib.extend(new TabView(),
     },
 
     /**
+     * Load HAR and HARP file. See {@link harModelLoader.loadArchives} for documentation.
+     */
+    loadArchives: function(hars, harps, callbackName, callback, errorCallback, doneCallback) {
+        var self = this;
+        return Loader.loadArchives(hars, harps, callbackName, function(jsonString) {
+            self.appendPreview(jsonString);
+            if (callback) {
+                callback.apply(this, arguments);
+            }
+        }, errorCallback, doneCallback);
+    },
+
+    /**
      * Use to customize list of request columns displayed by default.
      *
      * @param {String} cols Column names separated by a space.


### PR DESCRIPTION
Add doneCallback to harModelLoader.loadArchives(), so the caller knows
when all HARs/HARPs are loaded successfully.

Add harViewer.loadArchives() method that mirrors
harModelLoader.loadArchives(). This enables callers to load multiple
HARs/HARPs programmatically. E.g.:

  var harViewer = content.repObject;
  harViewer.loadArchives(hars, harps,
                         callbackName,
                         callback, errorCallback, doneCallback)

Add tests for harModelLoader.loadArchives() and the doneCallback.

Refactor $.ajax() use into new harModelLoader.ajax() method that can be
easily substituted during tests.

doneCallback is useful for automation, such as with
https://github.com/gitgrimbo/harviewer-screenshot.