### PR TITLE
Fix #98

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -109,7 +109,7 @@
 
         <!-- Load the analytics include file, as we're going to insert it into all the PHP/HTML files. -->
         <loadfile property="analytics.include" srcFile="${build.dir}/analytics.include"/>
-        <replace dir="${build.dir}" value="${analytics.include}" includes="*.php">
+        <replace dir="${build.dir}" value="${analytics.include}" includes="*.php, *.html">
             <replacetoken><![CDATA[<!--@GOOGLE-ANALYTICS-INCLUDE@-->]]></replacetoken>
         </replace>
 

--- a/webapp/preview.html
+++ b/webapp/preview.html
@@ -11,6 +11,3 @@
     <!--@GOOGLE-ANALYTICS-INCLUDE@-->
 </body>
 </html>
-<!--
-This file can be removed as it's replaced by preview.html?
--->

--- a/webapp/scripts/tabs/aboutTab.html
+++ b/webapp/scripts/tabs/aboutTab.html
@@ -9,7 +9,7 @@
 <a href="@HAR_SPEC_URL@">
     HTTP Archive (HAR)</a>
 log files created by HTTP tracking tools. These files contain log of HTTP
-client/server conversation and can be used for an additional analysis of e.g. 
+client/server conversation and can be used for an additional analysis of e.g.
 page load performance.</p>
 
 <p>User interface of this tool is composed from the following tabs:</p>
@@ -174,6 +174,26 @@ Refused to execute script from 'https://raw.githubusercontent.com/janodvarko/har
 SEC7112: Script from https://raw.githubusercontent.com/janodvarko/harviewer/master/webapp/examples/inline-scripts-block.harp?callback=onInputData&_=1469983439613 was blocked due to mime type mismatch
 </blockquote>
 </p>
+
+<h4>Embedding</h4>
+<p>Use <code>&lt;div&gt;</code> tags with a CSS class of "har" and the <code>data-har-url</code> or <code>data-harp-url</code> attribute as follows:</p>
+<p>
+<textarea readonly rows="12" style="width: 100%">
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <script src="https://code.jquery.com/jquery-2.2.4.min.js"></script>
+    <script src="https://gitgrimbo.github.io/harviewer/master/har.js" id="har"></script>
+</head>
+<body>
+    <div class="har" data-har-url="http://localhost:8111/my-har.har" height="800px"></div>
+    <div class="har" data-harp-url="http://localhost:8111/my-harp.harp" height="800px"></div>
+</body>
+</html>
+</textarea>
+</p>
+
 </td></tr>
 
 </table>


### PR DESCRIPTION
1) Use the 'new-style' HAR and HARP loading for previews.

Old style:

An element's "data-har" attribute is inspected to see if it's
an absolute URL or not.  If it's absolute it's assumed to be a HARP
file (cross-domain).  If it's not absolute, it's assumed to be a HAR
file (same-domain).

New-style:

If an element has a "data-har-url" attribute, this is treated as a HAR
file whether or not it is same-domain.  The user must rely on correct
CORS settings to be able to read cross-domain HAR files.

If an element has a "data-harp-url" attribute, this is treated as a HARP
file whether or not it is same-domain.

2) Replace preview.php with preview.html.