### PR TITLE
Update text of issue link

### DIFF
--- a/webapp/scripts/tabs/aboutTab.html
+++ b/webapp/scripts/tabs/aboutTab.html
@@ -28,7 +28,7 @@ page load performance.</p>
 <p>Feedback: <a href="http://groups.google.com/group/http-archive-specification">
     http://groups.google.com/group/http-archive-specification</a></p>
 <p>Report issue: <a href="https://github.com/janodvarko/harviewer/issues">
-    http://code.google.com/p/harviewer/issues/list</a></p>
+    https://github.com/janodvarko/harviewer/issues</a></p>
 <p>HAR Viewer Customization: <a href="http://code.google.com/p/harviewer/wiki/Customization">
     http://code.google.com/p/harviewer/wiki/Customization</a></p>
 </td></tr>


### PR DESCRIPTION
Hopefully a new version can be released before too long so that the main website is updated. Right now http://www.softwareishard.com/har/viewer/ is still linking out to code.google.com for the issues, and that's the page that came up from a Google search. Had to do some digging to find the Github page.