### PR TITLE
Dockerfile: Multi-stage build with Node.js and Ant with Runtime in Ap…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:6-wheezy as builder
+
+RUN apt-get update -y && \
+    apt-get install -y ant
+
+ADD . /build
+
+WORKDIR /build
+
+RUN npm install && \
+    ant build 
+
+FROM php:apache
+
+MAINTAINER marcello.desales@gmail.com
+LABEL github.com https://github.com/marcellodesales/harviewer
+
+COPY --from=builder /build/webapp-build /var/www/html
+
+EXPOSE 80


### PR DESCRIPTION
…ache/PHP

Using the snippets from the following work:

* https://github.com/mrorgues/dockerfiles/tree/master/har_viewer_builder
* https://github.com/mrorgues/dockerfiles/tree/master/har_viewer

The build will make all the necessary calls, while the runtime runs
Apache with PHP as it is required.

# Build

* Docker image deployed at https://hub.docker.com/r/marcellodesales/harviewer/

```
$ docker build -t harviewer .
Sending build context to Docker daemon   77.2MB
Step 1/10 : FROM node:6-wheezy as builder
 ---> d782cc30cf7b
Step 2/10 : RUN apt-get update -y &&     apt-get install -y ant
 ---> Using cache
 ---> e02e345efa03
Step 3/10 : ADD . /build
 ---> Using cache
 ---> f4c16fa28572
Step 4/10 : WORKDIR /build
 ---> Using cache
 ---> d8eff6fb4a7b
Step 5/10 : RUN npm install &&     ant build
 ---> Using cache
 ---> 5563e3e09bd6
Step 6/10 : FROM php:apache
 ---> ac8c4378955f
Step 7/10 : MAINTAINER marcello.desales@gmail.com
 ---> Using cache
 ---> 395c01f9c851
Step 8/10 : LABEL github.com https://github.com/marcellodesales/harviewer
Dockerfile: Multi-stage build with Node.js and Ant with Runtime in Apache/PHP
 ---> Using cache
 ---> 96a8cfd13b3d
Step 9/10 : COPY --from=builder /build/webapp-build /var/www/html
 ---> Using cache
 ---> 3464ac53f1b7
Step 10/10 : EXPOSE 80
 ---> Using cache
 ---> 26195a9456d3
Successfully built 26195a9456d3
Successfully tagged harviewer:latest
```

# Running

```
$ docker run -ti -p 8080:80 harviewer
AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 172.17.0.2. Set the 'ServerName' directive globally to suppress this message
AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 172.17.0.2. Set the 'ServerName' directive globally to suppress this message
[Fri Apr 27 00:15:26.090641 2018] [mpm_prefork:notice] [pid 1] AH00163: Apache/2.4.25 (Debian) PHP/7.2.4 configured -- resuming normal operations
[Fri Apr 27 00:15:26.090714 2018] [core:notice] [pid 1] AH00094: Command line: 'apache2 -D FOREGROUND'
172.17.0.1 - - [27/Apr/2018:00:15:33 +0000] "GET / HTTP/1.1" 200 858 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36"
172.17.0.1 - - [27/Apr/2018:00:15:33 +0000] "GET /scripts/require.js HTTP/1.1" 200 7021 "http://localhost:8080/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36"
172.17.0.1 - - [27/Apr/2018:00:15:33 +0000] "GET /css/harViewer.css HTTP/1.1" 20
```