### PR TITLE
add example of embedding. see #130

### DIFF
--- a/build-tools/build.js
+++ b/build-tools/build.js
@@ -55,6 +55,7 @@ replace.sync({
     files: [
         `${buildDir}/*.php`,
         `${buildDir}/*.html`,
+        `${buildDir}/examples/*.html`,
     ],
     from: /@VERSION@/g,
     to: version,
@@ -83,6 +84,7 @@ replace.sync({
     files: [
         `${buildDir}/*.php`,
         `${buildDir}/*.html`,
+        `${buildDir}/examples/*.html`,
     ],
     from: /<!--@GOOGLE-ANALYTICS-INCLUDE@-->/g,
     to: analyticsInclude,

--- a/webapp/css/harPreview.css
+++ b/webapp/css/harPreview.css
@@ -1,16 +1,36 @@
 /* See license.txt for terms of usage */
 
+@import url("harView.css");
+
+/* Domplate Widgets */
 @import url("tabView.css");
+@import url("toolbar.css");
+@import url("domTree.css");
 @import url("infoTip.css");
 @import url("popupMenu.css");
-@import url("toolbar.css");
+/* @import url("tableView.css"); -- preview does not support tableView (part of JSON Query UI) */
 
+/* HAR Preview */
 @import url("pageList.css");
 @import url("requestList.css");
 @import url("requestBody.css");
 
 @import url("previewMenu.css");
+
+@import url("harStats.css");
+@import url("pageTimeline.css");
+
 @import url("validationError.css");
+
+/* Application Tabs */
+/* @import url("aboutTab.css"); -- viewer mode only */
+/* @import url("homeTab.css"); -- viewer mode only */
+/* @import url("domTab.css"); -- viewer mode only */
+/* @import url("schemaTab.css"); -- viewer mode only */
+/* @import url("previewTab.css"); -- viewer mode only */
+/* @import url("search.css"); -- viewer mode only */
 
 /* Syntax Highlighter */
 @import url("SyntaxHighlighter.css");
+
+/* @import url("dragdrop.css");  -- viewer mode only */

--- a/webapp/css/harViewer.css
+++ b/webapp/css/harViewer.css
@@ -15,8 +15,11 @@
 @import url("requestList.css");
 @import url("requestBody.css");
 
+/* @import url("previewMenu.css"); -- preview mode only */
+
 @import url("harStats.css");
 @import url("pageTimeline.css");
+
 @import url("validationError.css");
 
 /* Application Tabs */
@@ -31,4 +34,3 @@
 @import url("SyntaxHighlighter.css");
 
 @import url("dragdrop.css");
-

--- a/webapp/examples/embed.html
+++ b/webapp/examples/embed.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html>
+
+<head>
+  <title>HTTP Archive Viewer @VERSION@ - Embedding Samples</title>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <style>
+    h1 { font-size: 12pt; }
+  </style>
+</head>
+
+<body>
+
+<p>View source to see examples of how to embed HAR Viewer into your page.</p>
+
+<p id="embedContainer">
+  Embed <input data-role="url" placeholder="Enter HAR/HARP URL here" size="32" /> as
+  <label for="embedAsHAR">HAR<input id="embedAsHAR" type="radio" name="harOrHarp" value="HAR" checked /></label> or
+  <label for="embedAsHARP">HARP<input id="embedAsHARP" type="radio" name="harOrHarp" value="HARP" /></label> with height
+  <input data-role="height" placeholder="150px" value="150px" size="6" />
+  <button data-role="embed">Embed</button>
+  <button data-role="clear">Clear Page</button>
+</p>
+
+<script>
+(function(embedContainer) {
+  function clickEmbed(e) {
+    var url = embedContainer.querySelector("[data-role=url]").value;
+    if (!url) {
+      return alert("url is required!");
+    }
+    var height = embedContainer.querySelector("[data-role=height]").value;
+    if (height === "") {
+      height = "150px";
+    }
+    var harOrHarp = [].slice.call(embedContainer.querySelectorAll("input[name=harOrHarp]")).filter(function(input) {
+      return input.checked;
+    })[0].value;
+
+    embed(url, harOrHarp, height);
+
+    // harInitialize() provided by har.js - finds all "har" DIVs and turns into IFRAMEs
+    window.harInitialize();
+  }
+
+  function clickClear() {
+    [].slice.call(document.querySelectorAll("[data-role=embedContainer]")).forEach(function(embedContainer) {
+      embedContainer.parentElement.removeChild(embedContainer);
+    });
+  }
+
+  embedContainer.querySelector("button[data-role=embed]").addEventListener("click", clickEmbed);
+  embedContainer.querySelector("button[data-role=clear]").addEventListener("click", clickClear);
+}(document.getElementById("embedContainer")));
+
+function relativeToAbsolute(url) {
+  if (url.indexOf("//") > -1) {
+    return url;
+  }
+  // trick using <a> element to turn relative URLs into absolute.
+  var a = document.createElement("a");
+  a.href = url;
+  return a.href;
+}
+function div(attr, url, height) {
+  var div = document.createElement("div");
+  div.className = "har";
+  div.setAttribute(attr, url);
+  div.setAttribute("height", height);
+  return div;
+}
+function harDiv(url, height) {
+  return div("data-har-url", url, height);
+}
+function harpDiv(url, height) {
+  return div("data-harp-url", url, height);
+}
+function embed(url, harOrHarp, height) {
+  var d = document.createElement("div");
+  d.setAttribute("data-role", "embedContainer");
+  d.innerHTML = "<h1>" + url + " as " + harOrHarp + "</h1>";
+  d.appendChild(harOrHarp === "HAR" ? harDiv(url, height) : harpDiv(url, height));
+  document.body.appendChild(d);
+}
+// Relative URLs will be interpreted as relative to "preview.html",
+// which is the src URL of the inserted IFRAME
+// (use your browser's devtools to view the URLs of the IFRAMEs inserted in this page).
+// So use URLs that are relative to "preview.html", otherwise convert URLs that are relative
+// to THE EMBEDDING PAGE into absolute URLs for "preview.html" to load.
+</script>
+
+<!-- Examples using JavaScript to create the DOM elements that "har.js" will process. -->
+
+<script>embed(relativeToAbsolute("./browser-blocking-time.har"), "HAR", "150px")</script>
+
+<script>embed(relativeToAbsolute("./inline-scripts-block.harp.js"), "HARP", "150px")</script>
+
+<!-- Examples using HTML to create the DOM elements that "har.js" will process. -->
+
+<div data-role="embedContainer">
+<h1>HAR/HTML</h1>
+<div class="har" data-har-url="http://localhost:8080/har.har" height="150px"></div>
+</div>
+
+<div data-role="embedContainer">
+<h1>HARP/HTML</h1>
+<div class="har" data-harp-url="./examples/inline-scripts-block.harp.js" height="150px"></div>
+</div>
+
+<script src="../har.js" id="har"></script>
+<!--@GOOGLE-ANALYTICS-INCLUDE@-->
+
+</body>
+
+</html>

--- a/webapp/scripts/tabs/aboutTab.html
+++ b/webapp/scripts/tabs/aboutTab.html
@@ -176,6 +176,7 @@ SEC7112: Script from https://raw.githubusercontent.com/janodvarko/harviewer/mast
 </p>
 
 <h4>Embedding</h4>
+<p>See the <a href="./examples/embed.html">Embedding example page</a> for examples of embedding a HAR into another page.</p>
 <p>Use <code>&lt;div&gt;</code> tags with a CSS class of "har" and the <code>data-har-url</code> or <code>data-harp-url</code> attribute as follows:</p>
 <p>
 <textarea readonly rows="12" style="width: 100%">

--- a/webapp/scripts/tabs/homeTab.html
+++ b/webapp/scripts/tabs/homeTab.html
@@ -28,6 +28,7 @@ Blocking time</span> - Impact of a limit of max number of parallel connections.<
 Browser cache</span> - Impact of the browser cache on page load (the same page loaded three times).</li>
 <li><span id="example4" class="link example" har="examples/google.com.har">
 Single page</span> - Single page load (empty cache).</li>
+<li><a href="./examples/embed.html">Embedding HAR Viewer</a> - into other pages.</li>
 </ul>
 <h3>HAR Logs Online </h3>
 For all the ways you can load HAR files into HAR Viewer, see the <span class="linkAbout link">About</span> tab.


### PR DESCRIPTION
A link to the new embed.html page is given on the home page and the
about page.

Fix styling issue where the preview mode does not display tabs like
"Response" and "JSON" correctly because of missing styles.

Update harViewer.css and harPreview.css to try and have the same CSS
imports on the same lines, for ease of comparison between the two.

Closes #130.