### PR TITLE
Replace trailing colon with semicolon in page timeline CSS

### DIFF
--- a/webapp/css/pageTimeline.css
+++ b/webapp/css/pageTimeline.css
@@ -36,7 +36,7 @@
 
 .pageBar.selected {
     opacity: 0.5; /* Safari, Opera */
-    -moz-opacity: 0.50: /* FireFox */
+    -moz-opacity: 0.50; /* FireFox */
     filter: alpha(opacity=50); /* IE */
 }
 


### PR DESCRIPTION
Fixes a CSS typo